### PR TITLE
fix: resolve critical lifecycle issues in TakePicturePage

### DIFF
--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -7,8 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_gstreamer_player/flutter_gstreamer_player.dart';
 import '../controllers/imageController.dart';
 
-GlobalKey cameraKey = GlobalKey();
-
 class TakePicturePage extends StatefulWidget {
   const TakePicturePage({Key? key}) : super(key: key);
 
@@ -19,6 +17,7 @@ class TakePicturePage extends StatefulWidget {
 class _TakePicturePageState extends State<TakePicturePage>
     with TickerProviderStateMixin {
   final ImageController imageController = Get.put(ImageController());
+  final GlobalKey cameraKey = GlobalKey();
   int _countdown = 5;
   Timer? _timer;
   int _picturesTaken = 0;
@@ -36,6 +35,7 @@ class _TakePicturePageState extends State<TakePicturePage>
       vsync: this,
       duration: Duration(milliseconds: 300),
     );
+    _selectedType = Get.arguments as int?;
     _initializeCamera();
   }
 
@@ -59,14 +59,13 @@ class _TakePicturePageState extends State<TakePicturePage>
 
   @override
   void dispose() {
+    _timer?.cancel();
     _animationController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    _selectedType = Get.arguments as int?;
-
     if (_selectedType == null || _selectedType! <= 0) {
       return Scaffold(
         appBar: AppBar(
@@ -205,6 +204,7 @@ class _TakePicturePageState extends State<TakePicturePage>
     });
 
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
+      if (!mounted) return;
       setState(() {
         if (_countdown > 0) {
           _countdown--;
@@ -342,6 +342,7 @@ class _TakePicturePageState extends State<TakePicturePage>
   }
 
   void _captureAndSaveImage() async {
+    if (!mounted) return;
     try {
       RenderRepaintBoundary boundary =
           cameraKey.currentContext!.findRenderObject() as RenderRepaintBoundary;


### PR DESCRIPTION
## Summary
- Timer 메모리 누수 수정: `dispose()`에서 `_timer?.cancel()` 추가
- GlobalKey를 파일 스코프에서 State 클래스 인스턴스 필드로 이동 (중복 키 크래시 방지)
- `Get.arguments` 읽기를 `build()`에서 `initState()`로 이동
- 타이머 콜백과 캡처 메서드에 `mounted` 체크 추가

## Issues Fixed
- #1 Timer leak in dispose()
- #2 GlobalKey at file top level
- #3 Arguments read in build()
- #4 No mounted check in timer callbacks

## Test plan
- [ ] 사진 촬영 중 뒤로가기 시 크래시 없음 확인
- [ ] 빠른 더블탭으로 페이지 중복 생성 시 크래시 없음 확인
- [ ] 카운트다운 중 페이지 이탈 후 콘솔에 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)