### PR TITLE
fix: improve null safety in image processing

### DIFF
--- a/lib/helpers/images_overlay_helper.dart
+++ b/lib/helpers/images_overlay_helper.dart
@@ -138,7 +138,10 @@ Future<ui.Image> _resizeImage(ui.Image image, int width, int height) async {
 Future<ByteData> _imageToByteData(ui.Image image) async {
   final ByteData? byteData =
       await image.toByteData(format: ui.ImageByteFormat.png);
-  return byteData!;
+  if (byteData == null) {
+    throw StateError('Failed to convert image to PNG byte data');
+  }
+  return byteData;
 }
 
 Future<ui.Image> _decodeImageFromList(List<int> list) async {

--- a/lib/pages/printPage.dart
+++ b/lib/pages/printPage.dart
@@ -17,7 +17,7 @@ class PrintPage extends StatefulWidget {
 }
 
 class _PrintPageState extends State<PrintPage> {
-  late ByteData? _combinedImageData = ByteData(0);
+  ByteData? _combinedImageData;
   final ImageController imageController = Get.find();
 
   @override


### PR DESCRIPTION
## Summary
- `_imageToByteData`에서 `byteData!` 강제 unwrap을 설명적 `StateError`로 교체
- PrintPage의 `_combinedImageData` 초기화를 `null`로 변경하여 로딩 상태 정상 동작

## Issues Fixed
- #5 Force unwrap in images_overlay_helper
- #6 PrintPage _combinedImageData initialization

## Test plan
- [ ] 이미지 합성 실패 시 앱 크래시 대신 에러 메시지 출력 확인
- [ ] PrintPage 진입 시 이미지 로딩 전 빈 화면(로딩 상태) 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)