### PR TITLE
chore: improve code quality and fix naming issues

### DIFF
--- a/lib/helpers/images_overlay_helper.dart
+++ b/lib/helpers/images_overlay_helper.dart
@@ -9,7 +9,7 @@ Future<ByteData> createOverlayImage({
   double firstRowTopSpacing = 0, // 1행의 위쪽 여백
   double firstColumnLeftSpacing = 0, // 1열의 왼쪽 여백
   double secondColumnLeftSpacing = 0, // 2번째 열의 왼쪽 여백
-  double secongRowTopSpacing = 0, // 2행의 위쪽 여백
+  double secondRowTopSpacing = 0, // 2행의 위쪽 여백
 }) async {
   final ui.Image background =
       await _decodeImageFromList(backgroundImage.buffer.asUint8List());
@@ -25,12 +25,15 @@ Future<ByteData> createOverlayImage({
     firstRowTopSpacing: firstRowTopSpacing,
     firstColumnLeftSpacing: firstColumnLeftSpacing,
     secondColumnLeftSpacing: secondColumnLeftSpacing,
-    secongRowTopSpacing: secongRowTopSpacing,
+    secondRowTopSpacing: secondRowTopSpacing,
   );
 
   final ByteData byteData = await _imageToByteData(combinedImage);
   return byteData;
 }
+
+const int _kSinglePhotoWidth = 1080;
+const int _kSinglePhotoHeight = 1440;
 
 Future<ui.Image> _drawImages({
   required ui.Image background,
@@ -40,7 +43,7 @@ Future<ui.Image> _drawImages({
   required double firstRowTopSpacing, // 1행의 위쪽 여백
   required double firstColumnLeftSpacing, // 1열의 왼쪽 여백
   required double secondColumnLeftSpacing, // 2번째 열의 왼쪽 여백
-  required double secongRowTopSpacing, // 2행의 위쪽 여백
+  required double secondRowTopSpacing, // 2행의 위쪽 여백
 }) async {
   final ui.PictureRecorder recorder = ui.PictureRecorder();
   final ui.Canvas canvas = ui.Canvas(recorder);
@@ -59,7 +62,7 @@ Future<ui.Image> _drawImages({
     final ByteData overlayData = overlayImages[0];
     final ui.Image overlay =
         await _decodeImageFromList(overlayData.buffer.asUint8List());
-    final ui.Image resizedOverlay = await _resizeImage(overlay, 1080, 1440);
+    final ui.Image resizedOverlay = await _resizeImage(overlay, _kSinglePhotoWidth, _kSinglePhotoHeight);
 
     final double overlayX = startX;
     final double overlayY = startY;
@@ -87,7 +90,7 @@ Future<ui.Image> _drawImages({
         }
       } else {
         // 2행
-        startY = overlayHeight + secongRowTopSpacing;
+        startY = overlayHeight + secondRowTopSpacing;
         if ((i + 1) % colCount == 0) {
           // 2열
           startX = overlayWidth + secondColumnLeftSpacing;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,7 @@ class MyApp extends StatelessWidget {
           page: () => const PrintPage(),
         )
       ],
-      title: 'Flutter Demo',
+      title: 'Linux Photo Booth',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,

--- a/lib/pages/homePage.dart
+++ b/lib/pages/homePage.dart
@@ -1,11 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-const List<Widget> icons = <Widget>[
-  Icon(Icons.square_rounded, size: 48),
-  Icon(Icons.window, size: 48),
-];
-
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
 

--- a/lib/pages/printPage.dart
+++ b/lib/pages/printPage.dart
@@ -43,7 +43,7 @@ class _PrintPageState extends State<PrintPage> {
         firstRowTopSpacing: 226, // 1행의 위쪽 여백
         firstColumnLeftSpacing: 60, // 1열의 왼쪽 여백
         secondColumnLeftSpacing: 15, // 2번째 열의 왼쪽 여백
-        secongRowTopSpacing: 65, // 2행의 위쪽 여백
+        secondRowTopSpacing: 65, // 2행의 위쪽 여백
       );
 
       if (mounted) {

--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -16,6 +16,9 @@ class TakePicturePage extends StatefulWidget {
 
 class _TakePicturePageState extends State<TakePicturePage>
     with TickerProviderStateMixin {
+  static const double kPreviewWidth = 525.0;
+  static const double kPreviewHeight = 700.0;
+
   final ImageController imageController = Get.put(ImageController());
   final GlobalKey cameraKey = GlobalKey();
   int _countdown = 5;
@@ -48,12 +51,12 @@ class _TakePicturePageState extends State<TakePicturePage>
         _cameraInitialized = true;
       });
       
-      print('Camera initialization completed');
+      debugPrint('Camera initialization completed');
     } catch (e) {
       setState(() {
         _cameraError = 'Camera initialization failed: $e';
       });
-      print('Camera initialization error: $e');
+      debugPrint('Camera initialization error: $e');
     }
   }
 
@@ -117,8 +120,8 @@ class _TakePicturePageState extends State<TakePicturePage>
                 children: [
                   Center(
                     child: SizedBox(
-                      width: 525.0,
-                      height: 700.0,
+                      width: kPreviewWidth,
+                      height: kPreviewHeight,
                       child: Stack(
                         children: [
                           RepaintBoundary(
@@ -190,8 +193,8 @@ class _TakePicturePageState extends State<TakePicturePage>
       duration: Duration(milliseconds: 300),
       opacity: _animationController.value,
       child: Container(
-        width: 525.0,
-        height: 700.0,
+        width: kPreviewWidth,
+        height: kPreviewHeight,
         color: Colors.white,
       ),
     );
@@ -224,8 +227,8 @@ class _TakePicturePageState extends State<TakePicturePage>
     // 에러가 있으면 에러 화면 표시
     if (_cameraError != null) {
       return Container(
-        width: 525.0,
-        height: 700.0,
+        width: kPreviewWidth,
+        height: kPreviewHeight,
         color: Colors.black,
         child: Center(
           child: Column(
@@ -258,8 +261,8 @@ class _TakePicturePageState extends State<TakePicturePage>
     // 초기화 중이면 로딩 화면 표시
     if (!_cameraInitialized) {
       return Container(
-        width: 525.0,
-        height: 700.0,
+        width: kPreviewWidth,
+        height: kPreviewHeight,
         color: Colors.black,
         child: Center(
           child: Column(
@@ -283,15 +286,15 @@ class _TakePicturePageState extends State<TakePicturePage>
         pipeline: _getCameraPipeline(),
       );
     } catch (e) {
-      print('GStreamer initialization error: $e');
+      debugPrint('GStreamer initialization error: $e');
       if (mounted) {
         setState(() {
           _cameraError = 'GStreamer initialization failed: $e';
         });
       }
       return Container(
-        width: 525.0,
-        height: 700.0,
+        width: kPreviewWidth,
+        height: kPreviewHeight,
         color: Colors.black,
         child: Center(
           child: Column(
@@ -361,7 +364,7 @@ class _TakePicturePageState extends State<TakePicturePage>
         });
       }
     } catch (e) {
-      print('Error capturing image: $e');
+      debugPrint('Error capturing image: $e');
       setState(() {
         _takingPicture = false;
       });


### PR DESCRIPTION
## Summary
- 파라미터 오타 수정: `secongRowTopSpacing` → `secondRowTopSpacing`
- `homePage.dart`에서 미사용 `icons` 상수 제거
- 앱 타이틀 `Flutter Demo` → `Linux Photo Booth`로 변경
- `print()` → `debugPrint()` 교체 (takePicturePage)
- 매직 넘버를 named constants로 추출 (카메라 프리뷰 크기, 단일 사진 해상도)

## Issues Fixed
- #12 Magic numbers
- #13 Typo in parameter name
- #15 App title is 'Flutter Demo'
- #16 print() should be debugPrint()
- #17 Dead code

## Test plan
- [ ] 사진 촬영 및 프리뷰 정상 동작 확인
- [ ] 1장/4장 모드 모두 이미지 합성 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)