### PR TITLE
test: replace stale counter test with photo booth tests

### DIFF
--- a/test/image_controller_test.dart
+++ b/test/image_controller_test.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linux_photo_booth/controllers/imageController.dart';
+
+void main() {
+  group('ImageController', () {
+    late ImageController controller;
+
+    setUp(() {
+      controller = ImageController();
+    });
+
+    test('starts with empty capturedImages list', () {
+      expect(controller.capturedImages, isEmpty);
+    });
+
+    test('can add captured images', () {
+      final testData = ByteData(10);
+      controller.capturedImages.add(testData);
+      expect(controller.capturedImages.length, 1);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,15 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:linux_photo_booth/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('App launches and shows home page', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify home page content is displayed
+    expect(find.text('사진 모드를 선택하세요:'), findsOneWidget);
+    expect(find.text('1장'), findsOneWidget);
+    expect(find.text('4장'), findsOneWidget);
+    expect(find.text('사진 촬영 시작'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- 기본 Flutter 카운터 테스트를 실제 앱 스모크 테스트로 교체
- `ImageController` 유닛 테스트 추가
- 홈 화면 렌더링 검증 (한국어 UI 텍스트 확인)

## Issues Fixed
- #18 Stale/broken test

## Test plan
- [ ] `flutter test` 실행 시 모든 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)