### PR TITLE
feat: make camera preview box size runtime-tunable via env

### DIFF
--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -17,8 +17,13 @@ class TakePicturePage extends StatefulWidget {
 
 class _TakePicturePageState extends State<TakePicturePage>
     with TickerProviderStateMixin {
-  static const double kPreviewWidth = 525.0;
-  static const double kPreviewHeight = 700.0;
+  // Preview (and captured photo) box. Tunable at runtime via env so the framing
+  // can be dialed in without a rebuild — a wider box crops less of the camera's
+  // 4:3 field of view. Defaults keep the original 3:4 portrait.
+  static final double kPreviewWidth =
+      double.tryParse(Platform.environment['BOOTH_PREVIEW_WIDTH'] ?? '') ?? 525.0;
+  static final double kPreviewHeight =
+      double.tryParse(Platform.environment['BOOTH_PREVIEW_HEIGHT'] ?? '') ?? 700.0;
 
   final ImageController imageController = Get.put(ImageController());
   final GlobalKey cameraKey = GlobalKey();


### PR DESCRIPTION
## Summary
`kPreviewWidth` / `kPreviewHeight` in the take-picture page now read `BOOTH_PREVIEW_WIDTH` / `BOOTH_PREVIEW_HEIGHT` from the environment, defaulting to the original **525x700 (3:4)**.

3:4 matches the printed single-photo aspect (`_kSinglePhotoWidth/Height` = 1080x1440), so the preview/capture stays WYSIWYG with the print by default; the env knob just allows on-device framing tweaks without a rebuild.

## Context
Follow-up to #13. The Pi 5 "too zoomed" issue was the imx219 640x480 sensor **crop**, already fixed there by capturing the full-FOV 1640x1232 binned mode. The 3:4 side crop is intentional (= print ratio), so the default is unchanged.