### PR TITLE
chore: rename to Ubu4Cut, refresh docs, and fix 360° kiosk rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ app.*.map.json
 # Ubuntu Core image build (ubuntu-core/build-image.sh) outputs
 /out/
 *.snap
-photobooth.model
+ubu4cut.model

--- a/README.md
+++ b/README.md
@@ -1,458 +1,267 @@
-# Linux Photo Booth
+# Ubu4Cut
 
-A professional photo booth application designed for Ubuntu Core and Ubuntu Frame. Perfect for events, parties, and commercial photo booth installations.
+**Ubu4Cut** is an Ubuntu-based four-cut (네컷) photo booth for touch kiosks. It ships as a
+single Flutter/GTK **snap** that autostarts under **Ubuntu Frame** on **Ubuntu Core**
+(Raspberry Pi 5) and also launches manually on **Ubuntu Desktop**. Point-and-shoot capture,
+frame overlays, and direct dye-sub printing — built for events, parties, and permanent booth
+installations.
 
-## Overview
-
-Linux Photo Booth is a complete photo booth solution that runs seamlessly on Ubuntu Core with Ubuntu Frame, providing a touch-optimized interface for capturing, editing, and printing photos. It's designed to work out-of-the-box on Raspberry Pi and other Ubuntu Core devices.
+> **Status:** `grade: devel`, `confinement: devmode`.
+> The Raspberry Pi 5 CSI camera needs libcamera to open `/dev/media*`, which snapd's strict
+> `camera` interface does not grant (it only tags `/dev/video*`). Until a gadget
+> `custom-device` slot is in place, the kiosk runs in devmode. See
+> [`ubuntu-core/gadget-camera-kms.md`](ubuntu-core/gadget-camera-kms.md).
 
 ## Features
 
-- **Real-time camera capture** using GStreamer
-- **Multiple photo layouts** (1x1, 2x2) with customizable frames
-- **Frame overlay system** with professional templates
-- **Direct printing** via CUPS with automatic printer detection
-- **Countdown timer** with visual feedback
-- **Touch-optimized interface** for kiosk environments
-- **Automatic kiosk mode** with Ubuntu Frame integration
-- **Background themes** and customization options
-- **Remote management** capabilities
-- **Secure sandboxed** environment with Snap confinement
+- **Two capture layouts** — 1-cut (`1장`) and 4-cut (`4장`), each with a live countdown.
+- **Real-time preview** via GStreamer — USB UVC (`v4l2src`) and Raspberry Pi CSI
+  (`libcamerasrc`, PiSP) are auto-detected at launch.
+- **Frame overlays** composited onto the captured shots before printing.
+- **Direct printing** through the CUPS `lp` client — no bundled web/print server. Media size
+  and borderless are snap-configurable; defaults suit 4×6 dye-sub photo printers.
+- **Touch-first kiosk UI** — large finger targets, instant page transitions, and a short
+  post-transition *tap guard* that swallows carried-over double-taps.
+- **Runtime portrait/landscape toggle** — rotates the widget tree (not the Frame output,
+  which would break touch mapping) so a physically rotated monitor still maps touches
+  correctly.
+- **Single snap, two entry points** — a desktop launcher and an Ubuntu Core kiosk daemon
+  share one Flutter binary.
+- **Kiosk autostart** under Ubuntu Frame on Ubuntu Core, with automatic restart.
 
-## Ubuntu Core + Ubuntu Frame
+## Architecture at a glance
 
-This application is specifically designed for Ubuntu Core, which provides:
+| Layer | Component | Notes |
+|---|---|---|
+| UI | Flutter + GetX | Routes: `/` (home) → `/take-picture-page` → `/print-page`. `lib/` |
+| Camera | `flutter_gstreamer_player` + GStreamer | Pipeline selected at runtime by `run-booth`. |
+| Pi 5 camera stack | libcamera (RPi fork, PiSP/rp1) | Built **from source** in the snap; Ubuntu 24.04 only ships libcamera 0.2.0 (Pi 4/VC4). |
+| Printing | `lp` (cups-client) → cups snap → Printer Application | e.g. `gutenprint-printer-app` for PNG→raster on dye-sub. |
+| Packaging | One snap `ubu4cut`, `gnome` extension | Apps: `ubu4cut` (desktop) + `ubu4cut-kiosk` (daemon). |
+| Compositor | Ubuntu Frame (Wayland) | On Ubuntu Core; the kiosk waits for its socket before launching. |
 
-- **Security**: Sandboxed applications with strict confinement
-- **Reliability**: Automatic updates and rollback capabilities
-- **Simplicity**: One-command installation and management
-- **Performance**: Optimized for IoT and edge computing devices
+### The two app entries
 
-Ubuntu Frame handles the display server and kiosk management automatically.
+Both share one Flutter binary via `bin/run-booth`:
 
-## Quick Start
+- **`ubu4cut`** — Ubuntu Desktop launcher (manual, from the app menu). `Exec=ubu4cut`.
+- **`ubu4cut-kiosk`** — Ubuntu Core kiosk daemon (`daemon: simple`,
+  `install-mode: disable`, `restart-condition: always`). It runs `wayland-launch` first to
+  wait for the Ubuntu Frame Wayland socket, and is enabled explicitly by
+  `setup-ubuntu-core.sh` (so it doesn't crash-loop on a desktop with no seat at boot).
 
-### 1. Install Ubuntu Core
+### Snap interfaces
 
-1. **Download Ubuntu Core image**
+The `gnome` extension (gnome-46-2404) provides the GTK/GLib/pixbuf/fontconfig/xkb/theme
+runtime plus Mesa and Wayland. The app additionally plugs:
+
+`camera`, `cups`, `opengl`, `wayland`, `desktop`, `desktop-legacy`, `gsettings`,
+`hardware-observe` (the kiosk daemon uses `camera`, `cups`, `opengl`, `wayland`,
+`hardware-observe`).
+
+Wayland-only — there is **no X11 path**. `cups` replaces the old `cups-control`, and
+`raw-usb` is no longer used.
+
+## Quick start — Ubuntu Core kiosk (Raspberry Pi 5)
+
+Ubuntu Core image choice on the Pi 5 is a real trade-off (measured on-device):
+
+| | Full KMS (display) | Onboard Wi-Fi |
+|---|---|---|
+| **Core 24** (kernel 6.8) | ❌ pinned to legacy FB | ✅ |
+| **Core 26** (kernel 7.0) | ✅ | ❌ brcmfmac scan regression |
+
+Ubuntu Frame (Wayland) needs full KMS, so the Pi 5 booth targets a **custom Core 26 image**
+that adds a local-login user — you log in on the Pi's own touch monitor and repair Wi-Fi from
+a shell, no console-conf needed. The whole flow is scripted under `ubuntu-core/`:
+
+1. **Build a signed custom image** — [`ubuntu-core/flash-and-verify.md`](ubuntu-core/flash-and-verify.md)
+   (`sign-model.sh` → `build-image.sh` → `make-auto-import.sh`).
+2. **Flash a spare SD**, boot with the `auto-import.assert` USB inserted, log in locally, and
+   bring up networking.
+3. **Install the booth + runtime and enable the kiosk:**
    ```bash
-   wget https://cdimage.ubuntu.com/ubuntu-core/24/stable/current/ubuntu-core-24-arm64+raspi.img.xz
-   xz -d ubuntu-core-24-arm64+raspi.img.xz
+   # Store install (when published):
+   sudo snap install ubu4cut
+   # Or local sideload:
+   sudo snap install --dangerous ubu4cut_*.snap
+
+   # Install Ubuntu Frame + CUPS + a dye-sub Printer Application, connect interfaces,
+   # and enable the kiosk daemon (sideloads don't auto-connect):
+   sudo ubuntu-core/setup-ubuntu-core.sh
    ```
+4. **Enable the CSI camera + full KMS** (gadget-owned `config.txt`) —
+   [`ubuntu-core/gadget-camera-kms.md`](ubuntu-core/gadget-camera-kms.md).
+5. **Verify on real hardware** — [`ubuntu-core/rpi5-acceptance-checklist.md`](ubuntu-core/rpi5-acceptance-checklist.md).
 
-2. **Flash to SD card**
-   ```bash
-   sudo dd if=ubuntu-core-24-arm64+raspi.img of=/dev/sdb bs=4M status=progress
-   ```
+`setup-ubuntu-core.sh` does the essential wiring only. It deliberately does **not** add cron
+monitors, `snap save` backups, `ufw`, or `logrotate`.
 
-3. **Boot and configure**
-   - Insert SD card into Raspberry Pi
-   - Connect to WiFi during initial setup
-   - Create Ubuntu One account if needed
-   - Note the device IP address
-
-### 2. Install Ubuntu Frame
+Verify the wiring:
 
 ```bash
-# SSH into your Ubuntu Core device
-ssh ubuntu@<device-ip>
-
-# Install Ubuntu Frame
-sudo snap install ubuntu-frame
-
-# Configure Frame for kiosk mode
-sudo snap set ubuntu-frame daemon.enable=true
-sudo snap set ubuntu-frame daemon.restart-condition=always
+snap connections ubu4cut          # expect camera, cups, wayland (no cups-control)
+snap services ubu4cut             # ubu4cut-kiosk should be enabled/active
+snap logs ubu4cut.ubu4cut-kiosk -n 50
 ```
 
-### 3. Install Photo Booth
+## Run on Ubuntu Desktop
+
+Install the snap and launch **Ubu4Cut** from the app menu (or run `ubu4cut`). Same binary; the
+kiosk daemon stays disabled on desktop.
+
+## Printing
+
+Printing goes straight from the app to CUPS through the `lp` client — there is no bundled print
+server.
+
+- Install CUPS and a **driverless-IPP Printer Application** for the dye-sub, e.g.
+  `gutenprint-printer-app` (`setup-ubuntu-core.sh` installs both).
+- Set the default printer once it is detected:
+  ```bash
+  lpstat -p                  # via the cups snap
+  sudo lpadmin -d <printer>  # or the CUPS web UI at http://localhost:631
+  ```
+- Configure photo media (defaults: **4×6 borderless**):
+  ```bash
+  snap set ubu4cut print.media=4x6 print.borderless=true
+  ```
+  The `configure` hook writes these to `$SNAP_DATA/print-config.env`; `run-booth` exports them
+  as `BOOTH_PRINT_MEDIA` / `BOOTH_PRINT_BORDERLESS`; the print page passes them to `lp`.
+
+## Camera
+
+`run-booth` picks the source at launch and exports `BOOTH_CAMERA_KIND` /
+`DEFAULT_CAMERA_DEVICE`, which the Dart pipeline reads:
+
+- **USB UVC** → `v4l2src device=/dev/videoN` (a genuine USB video node).
+- **Raspberry Pi CSI** → `libcamerasrc` capturing the full-FOV binned mode (NV12 1640×1232),
+  scaled to 640×480. The narrow 640×480 sensor mode is a crop and looks zoomed in, so it is
+  avoided.
+
+Because Ubuntu 24.04's stock libcamera (0.2.0) is Pi 4 (VC4) only, the snap builds the
+Raspberry Pi libcamera fork (PiSP/rp1) from source, including the `libcamerasrc` GStreamer
+element and the IPA/tuning data. Force a source with `BOOTH_CAMERA_KIND=libcamera` (or
+`v4l2` together with `DEFAULT_CAMERA_DEVICE`).
+
+## Configuration (environment)
+
+Runtime-tunable at startup, no rebuild required:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `BOOTH_PORTRAIT` | `0` | `1` starts the UI in portrait. |
+| `BOOTH_PORTRAIT_TURNS` | `3` | Clockwise quarter-turns for portrait (`1` or `3`). |
+| `BOOTH_TAP_GUARD_MS` | `300` | Post-transition input guard; `0` disables it. |
+| `BOOTH_PREVIEW_WIDTH` / `BOOTH_PREVIEW_HEIGHT` | `525` / `700` | Preview & capture box size. |
+| `BOOTH_CAMERA_KIND` / `DEFAULT_CAMERA_DEVICE` | auto | Override camera detection. |
+| `BOOTH_PRINT_MEDIA` / `BOOTH_PRINT_BORDERLESS` | `4x6` / `true` | Set via `snap set … print.*`. |
+| `BOOTH_AUTOSTART_CAMERA` | unset | Test hook: auto-open the camera page. Off in production. |
+
+Only `print.media` / `print.borderless` are exposed as snap config; the rest are process
+environment variables (set them in `run-booth` or a systemd drop-in for the kiosk daemon).
+
+## Development
+
+Prerequisites: Flutter (Dart SDK ≥ 3.3). Snap builds need a Linux host with `snapcraft`
+(there is none on macOS).
 
 ```bash
-# Install from Snap Store (when published)
-sudo snap install linux-photo-booth
+flutter pub get
 
-# Or install locally built snap
-sudo snap install --dangerous linux-photo-booth_*.snap
+# Desktop dev (UI/logic):
+flutter run -d linux        # or -d macos for UI work
 
-# Connect required interfaces (desktop, wayland, x11, opengl are auto-connected via gnome extension)
-sudo snap connect linux-photo-booth:camera
-sudo snap connect linux-photo-booth:cups-control
-sudo snap connect linux-photo-booth:raw-usb
+# Snap build on a Linux host:
+./build-snap.sh             # snapcraft --use-lxd (local testing)
+snapcraft --destructive-mode # arm64, on an arm64 host
 ```
 
-### 4. Configure Ubuntu Frame
+To build **arm64 without a local snapcraft** (e.g. from macOS), use **Launchpad** or a
+privileged systemd Docker container — both, plus the no-hardware gate
+(`snapcraft lint`, `review-tools.snap-review`, `frame-it`), are documented in
+[`ubuntu-core/build-and-verify.md`](ubuntu-core/build-and-verify.md).
 
-```bash
-# Set photo booth as the default application
-sudo snap set ubuntu-frame daemon.command="linux-photo-booth"
+Notes:
+- `pubspec.yaml` overrides `win32: any` to drop it from Linux builds.
+- `packages/flutter_gstreamer_player` is vendored (a GStreamer-backed video widget).
 
-# Restart Frame to apply changes
-sudo snap restart ubuntu-frame
-```
-
-## Development Setup
-
-### Prerequisites
-
-```bash
-# Install snapcraft
-sudo snap install snapcraft --classic
-
-# Install Flutter
-sudo snap install flutter --classic
-
-# Install build dependencies
-sudo apt update
-sudo apt install -y \
-  build-essential \
-  git \
-  curl \
-  wget
-```
-
-### Build Snap Package
-
-```bash
-# Clone repository
-git clone https://github.com/your-username/flutter-linux-photo-booth.git
-cd flutter-linux-photo-booth
-
-# Build snap package (for local testing)
-./build-snap.sh
-
-# For Raspberry Pi (arm64) build, use:
-snapcraft --destructive-mode
-```
-
-### Test Locally
-
-```bash
-# Install snap in development mode
-sudo snap install --devmode linux-photo-booth_*.snap
-
-# Connect interfaces (desktop, wayland, x11, opengl are auto-connected via gnome extension)
-sudo snap connect linux-photo-booth:camera
-sudo snap connect linux-photo-booth:cups-control
-
-# Test the application
-linux-photo-booth
-```
-
-### Advanced Setup
-
-For advanced Ubuntu Core configuration, monitoring, and troubleshooting, see the detailed guide in [ubuntu-core/install-ubuntu-core.md](ubuntu-core/install-ubuntu-core.md).
-
-For automated setup of Ubuntu Core with all necessary services and monitoring, use the setup script:
-
-```bash
-# Run the automated setup script
-sudo ./ubuntu-core/setup-ubuntu-core.sh
-```
-
-## Project Structure
+## Project structure
 
 ```
-flutter-linux-photo-booth/
+ubu4cut/
 ├── lib/
-│   ├── controllers/          # State management (GetX)
-│   ├── helpers/             # Utility functions
-│   ├── pages/              # UI pages
-│   └── main.dart           # Application entry point
+│   ├── main.dart                 # App entry: routes, theme, whole-UI rotation
+│   ├── controllers/              # GetX controllers (image buffer, orientation)
+│   ├── pages/                    # home / take-picture / print
+│   ├── widgets/                  # tapGuard (post-transition input guard)
+│   └── helpers/                  # frame-overlay compositing
 ├── assets/
-│   ├── images/             # Frame templates and test images
-│   └── backgrounds/        # UI background images
+│   ├── images/                   # frame templates + test images
+│   └── backgrounds/              # UI backgrounds
 ├── snap/
-│   ├── snapcraft.yaml      # Snap package configuration
-│   ├── gui/               # Snap Store icon (linux-photo-booth.png)
+│   ├── snapcraft.yaml            # snap (gnome ext, libcamera-from-source, dual apps)
+│   ├── hooks/configure           # print.media / print.borderless -> env
 │   └── local/
-│       ├── run-booth       # Launcher script
-│       └── desktop/        # Desktop integration files
-├── ubuntu-core/
-│   ├── setup-ubuntu-core.sh # Ubuntu Core setup script
-│   └── install-ubuntu-core.md # Detailed installation guide
-├── server.py              # Flask print server
-├── requirement.txt        # Python dependencies
-└── build-snap.sh         # Snap build script
-```
-
-## Configuration
-
-### Ubuntu Frame Configuration
-
-Ubuntu Frame automatically handles kiosk mode. To customize the behavior:
-
-```bash
-# Configure Frame settings
-sudo snap set ubuntu-frame daemon.restart-condition=always
-sudo snap set ubuntu-frame daemon.restart-delay=10s
-
-# Set display environment
-sudo snap set ubuntu-frame daemon.environment="DISPLAY=:0 WAYLAND_DISPLAY=wayland-0"
-```
-
-### Camera Settings
-
-The application uses `/dev/video0` by default. To use a different camera:
-
-1. Edit `lib/pages/takePicturePage.dart`
-2. Modify the GStreamer pipeline in the `GstPlayer` widget
-3. Change `device=/dev/video0` to your camera device
-
-### Printer Configuration
-
-The Flask server automatically detects the default printer. To configure manually:
-
-1. Edit `server.py`
-2. Modify the `get_default_printer()` function
-3. Or set a specific printer name
-
-## Printer Setup
-
-### CUPS Installation
-
-```bash
-# Install CUPS snap
-sudo snap install cups
-
-# Enable CUPS web interface
-sudo snap set cups interface.enable=true
-
-# Connect USB printer interface
-sudo snap connect cups:usb-control
-```
-
-### Printer Configuration
-
-```bash
-# List available printers
-lpstat -p
-
-# Set default printer
-lpoptions -d <printer-name>
-
-# Test print
-echo "Test" | lp
-```
-
-### Web Interface
-
-Access CUPS web interface at `http://<device-ip>:631` to configure printers.
-
-## Monitoring and Management
-
-### Logs
-
-```bash
-# Application logs
-sudo snap logs linux-photo-booth
-
-# Ubuntu Frame logs
-sudo snap logs ubuntu-frame
-
-# System logs
-journalctl -u snap.ubuntu-frame.ubuntu-frame
-```
-
-### Status Check
-
-```bash
-# Check snap services
-snap services
-
-# Check snap connections
-snap connections linux-photo-booth
-
-# Check system resources
-htop
-df -h
-```
-
-### Remote Management
-
-```bash
-# SSH into device
-ssh ubuntu@<device-ip>
-
-# Restart application
-sudo snap restart linux-photo-booth
-
-# Update application
-sudo snap refresh linux-photo-booth
-
-# Check for updates
-sudo snap refresh --list
-```
-
-## Security
-
-### Snap Confinement
-
-The application runs in strict confinement, providing:
-
-- **Isolation**: Applications cannot access each other's data
-- **Permissions**: Explicit permission grants for hardware access
-- **Updates**: Automatic security updates
-- **Rollback**: Automatic rollback on failures
-
-### Interface Connections
-
-```bash
-# Required interfaces (desktop, wayland, x11, opengl are auto-connected via gnome extension)
-sudo snap connect linux-photo-booth:camera      # Camera access (manual connect required)
-sudo snap connect linux-photo-booth:cups-control # Printer access
-sudo snap connect linux-photo-booth:raw-usb     # USB device access
+│       ├── run-booth             # launcher: camera detect, GStreamer + print env
+│       ├── wayland-launch        # kiosk: wait for Frame's Wayland socket
+│       └── desktop/ubu4cut.desktop
+├── ubuntu-core/                  # Ubuntu Core / RPi 5 imaging + kiosk wiring
+│   ├── setup-ubuntu-core.sh      # install Frame/CUPS/Printer App, connect, enable kiosk
+│   ├── install-ubuntu-core.md    # advanced install & operations guide
+│   ├── build-and-verify.md       # snap build (Launchpad/Docker) + no-hardware gate
+│   ├── gadget-camera-kms.md      # CSI camera + full KMS via custom gadget/model
+│   ├── flash-and-verify.md       # custom Core 26 image + local-login (Wi-Fi rescue)
+│   ├── rpi5-acceptance-checklist.md
+│   ├── sign-model.sh / build-image.sh / make-auto-import.sh
+│   ├── model/                    # ubu4cut-core-24|26-pi-arm64 model assertions
+│   ├── gadget/                   # config.txt (KMS + camera) + camera-csi slot
+│   └── system-user.json          # local-login template (Core 26 path)
+├── packages/flutter_gstreamer_player/   # vendored GStreamer video widget
+├── linux/  macos/  test/         # Flutter platform runners + tests
+└── build-snap.sh
 ```
 
 ## Troubleshooting
 
-### Common Issues
+- **Black preview / test pattern instead of camera** — check `snap logs ubu4cut` for
+  `Camera: kind=…`. USB nodes must be genuine UVC; the Pi CSI needs the gadget `config.txt`
+  (`camera_auto_detect`) so `rp1-cfe` appears (`ls /dev/media*`,
+  `cat /sys/class/video4linux/*/name`). Reconnect with `sudo snap connect ubu4cut:camera`.
+- **Nothing renders under Ubuntu Frame** — full KMS is required (`ls /dev/dri/card0`). On the
+  Pi 5 that means Core 26 (or a custom Core 24 gadget). Check `snap services ubu4cut` and
+  `snap logs ubu4cut.ubu4cut-kiosk`.
+- **Printing fails** — `lpstat -p` (is the printer present?), default set (`lpadmin -d`),
+  and a Printer Application installed for PNG→raster. Reconfigure media with
+  `snap set ubu4cut print.media=…`.
+- **Interface check** — `snap connections ubu4cut` should show `camera`, `cups`, `wayland`
+  (and no `cups-control`).
 
-#### Camera Not Working
-```bash
-# Check camera permissions
-snap connections linux-photo-booth
+## Documentation map
 
-# Reconnect camera interface
-sudo snap disconnect linux-photo-booth:camera
-sudo snap connect linux-photo-booth:camera
-
-# Test camera
-v4l2-ctl --list-devices
-```
-
-#### Display Issues
-```bash
-# Check Frame service
-sudo snap services ubuntu-frame
-
-# Restart Frame
-sudo snap restart ubuntu-frame
-
-# Check display environment
-echo $DISPLAY
-echo $WAYLAND_DISPLAY
-```
-
-#### Printer Issues
-```bash
-# Check CUPS service
-sudo snap services cups
-
-# Check printer connections
-snap connections cups
-
-# Test printer
-lpstat -p
-echo "Test" | lp
-```
-
-### Debug Commands
-
-```bash
-# System information
-uname -a
-snap version
-
-# Hardware information
-lsusb
-lspci
-
-# Network information
-ip addr show
-ping -c 3 8.8.8.8
-```
-
-## Performance Optimization
-
-### Memory Optimization
-
-```bash
-# Monitor memory usage
-free -h
-
-# Check snap memory usage
-snap list --all
-```
-
-### Storage Optimization
-
-```bash
-# Check disk usage
-df -h
-
-# Clean old snap versions
-snap set system refresh.retain=2
-```
-
-## Updates and Maintenance
-
-### Automatic Updates
-
-Ubuntu Core automatically updates snaps in the background.
-
-### Manual Updates
-
-```bash
-# Check for updates
-sudo snap refresh --list
-
-# Update specific snap
-sudo snap refresh linux-photo-booth
-
-# Update all snaps
-sudo snap refresh
-```
-
-### Backup and Restore
-
-```bash
-# Create backup
-sudo snap save photo-booth-backup
-
-# List backups
-sudo snap saved
-
-# Restore from backup
-sudo snap restore <backup-id>
-```
+| Topic | File |
+|---|---|
+| Snap build + no-hardware gate | [`ubuntu-core/build-and-verify.md`](ubuntu-core/build-and-verify.md) |
+| Custom Core 26 image + Wi-Fi rescue | [`ubuntu-core/flash-and-verify.md`](ubuntu-core/flash-and-verify.md) |
+| CSI camera + full KMS (gadget/model) | [`ubuntu-core/gadget-camera-kms.md`](ubuntu-core/gadget-camera-kms.md) |
+| On-device acceptance | [`ubuntu-core/rpi5-acceptance-checklist.md`](ubuntu-core/rpi5-acceptance-checklist.md) |
+| Advanced install & operations | [`ubuntu-core/install-ubuntu-core.md`](ubuntu-core/install-ubuntu-core.md) |
+| Kiosk wiring script | [`ubuntu-core/setup-ubuntu-core.sh`](ubuntu-core/setup-ubuntu-core.sh) |
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-### Development Guidelines
-
-- Follow Flutter best practices
-- Add tests for new features
-- Update documentation for API changes
-- Ensure snap confinement compatibility
+1. Fork and branch (`git checkout -b feature/thing`).
+2. Follow Flutter conventions; keep snap confinement in mind.
+3. Add tests for new behavior and update the docs (including `ubuntu-core/`).
+4. Open a PR.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Support
-
-### Documentation
-- [Ubuntu Core Documentation](https://ubuntu.com/core/docs)
-- [Ubuntu Frame Documentation](https://snapcraft.io/ubuntu-frame)
-- [Snapcraft Documentation](https://snapcraft.io/docs)
-
-### Community
-- [Ubuntu Forums](https://ubuntuforums.org/)
-- [Snapcraft Community](https://forum.snapcraft.io/)
-
-### Issues
-- [GitHub Issues](https://github.com/your-username/flutter-linux-photo-booth/issues)
+MIT — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 
-- Ubuntu Core team for the excellent IoT platform
-- Flutter team for the amazing UI framework
-- GStreamer team for multimedia capabilities
-- CUPS team for printing support
-
+- Ubuntu Core & Ubuntu Frame (Canonical)
+- Flutter
+- GStreamer & libcamera
+- CUPS

--- a/build-snap.sh
+++ b/build-snap.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Linux Photo Booth Snap Builder
-# This script builds the snap package for the Linux Photo Booth application
+# Ubu4Cut Snap Builder
+# This script builds the snap package for the Ubu4Cut application
 
 set -e
 
-echo "Starting Linux Photo Booth Snap build..."
+echo "Starting Ubu4Cut Snap build..."
 
 # Check if snapcraft is installed
 if ! command -v snapcraft &> /dev/null; then
@@ -31,12 +31,12 @@ echo "Note: For Raspberry Pi (arm64) builds, use: snapcraft --destructive-mode"
 snapcraft --use-lxd
 
 # Check if build was successful
-if ls linux-photo-booth_*.snap 1> /dev/null 2>&1; then
+if ls ubu4cut_*.snap 1> /dev/null 2>&1; then
     echo "Snap package built successfully!"
-    echo "Package: $(ls linux-photo-booth_*.snap)"
+    echo "Package: $(ls ubu4cut_*.snap)"
     echo ""
     echo "To install the snap package:"
-    echo "   sudo snap install --dangerous linux-photo-booth_*.snap"
+    echo "   sudo snap install --dangerous ubu4cut_*.snap"
     echo ""
     echo "To test the snap package:"
     echo "   snapcraft try"

--- a/lib/controllers/orientationController.dart
+++ b/lib/controllers/orientationController.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'package:get/get.dart';
+
+/// Controls whole-app rotation so the booth can run on a physically rotated
+/// monitor without rotating the Ubuntu Frame output (display rotation breaks
+/// touch grab/mapping on Frame's Mir). `quarterTurns` feeds a `RotatedBox` in
+/// `main.dart` and cycles the full 360° in 90° steps:
+/// 0 = landscape, 1 = 90°, 2 = 180° (landscape flipped), 3 = 270°.
+///
+/// Initial state comes from env (BOOTH_PORTRAIT / BOOTH_PORTRAIT_TURNS) and it
+/// is rotated at runtime from the home screen.
+class OrientationController extends GetxController {
+  final RxInt quarterTurns = _initialTurns.obs;
+
+  /// Odd quarter-turns (90°, 270°) put the UI in portrait.
+  bool get isPortrait => quarterTurns.value.isOdd;
+
+  /// Current rotation, clockwise degrees (0 / 90 / 180 / 270).
+  int get degrees => quarterTurns.value * 90;
+
+  /// Rotate the whole UI 90° clockwise, wrapping after a full turn
+  /// (0 → 90 → 180 → 270 → 0).
+  void rotate() {
+    quarterTurns.value = (quarterTurns.value + 1) % 4;
+  }
+
+  /// Reset to native landscape (0°).
+  void resetToLandscape() {
+    quarterTurns.value = 0;
+  }
+
+  /// Clockwise quarter-turns used as the portrait *default* at startup. 3
+  /// (== 270°) is the common orientation; set BOOTH_PORTRAIT_TURNS=1 if the
+  /// monitor is turned the other way (i.e. the UI ends up upside down).
+  static int get _portraitTurns {
+    final v = int.tryParse(Platform.environment['BOOTH_PORTRAIT_TURNS'] ?? '');
+    if (v == null) return 3;
+    // Only 1 or 3 make sense for the portrait default; anything else -> 3.
+    return (v == 1 || v == 3) ? v : 3;
+  }
+
+  static int get _initialTurns =>
+      Platform.environment['BOOTH_PORTRAIT'] == '1' ? _portraitTurns : 0;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:get/get.dart';
 import 'pages/homePage.dart';
 import 'pages/takePicturePage.dart';
 import 'pages/printPage.dart';
+import 'controllers/orientationController.dart';
+import 'widgets/tapGuard.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,6 +26,9 @@ void main() async {
     DeviceOrientation.landscapeRight,
   ]);
 
+  // Whole-app rotation state (home-screen toggle + env default).
+  Get.put(OrientationController(), permanent: true);
+
   runApp(const MyApp());
 }
 
@@ -34,24 +39,71 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       debugShowCheckedModeBanner: false,
+      // Instant page switches — a kiosk feels more responsive without the
+      // default push animation, and it avoids taps landing mid-transition.
+      defaultTransition: Transition.noTransition,
+      transitionDuration: Duration.zero,
+      // Whole-app rotation: rotate the widget tree in-app instead of rotating
+      // the Ubuntu Frame output — display rotation breaks touch grab/mapping on
+      // this Mir version, so we keep the output landscape (touch stays correct)
+      // and rotate the tree. RotatedBox rotates hit-testing too, so touches map
+      // to the right widgets. The home screen cycles the full 360°
+      // (0 -> 90 -> 180 -> 270 -> 0) via OrientationController; initial state
+      // comes from env BOOTH_PORTRAIT / BOOTH_PORTRAIT_TURNS.
+      builder: (context, child) {
+        if (child == null) return const SizedBox.shrink();
+        final orientation = Get.find<OrientationController>();
+        return Obx(() {
+          final turns = orientation.quarterTurns.value;
+          if (turns == 0) return child;
+          final mq = MediaQuery.of(context);
+          // Only 90°/270° swap width<->height; 180° keeps the same dimensions.
+          final data = turns.isOdd
+              ? mq.copyWith(size: Size(mq.size.height, mq.size.width))
+              : mq;
+          return MediaQuery(
+            data: data,
+            child: RotatedBox(quarterTurns: turns, child: child),
+          );
+        });
+      },
       getPages: [
         GetPage(
           name: '/',
-          page: () => const HomePage(),
+          page: () => const TapGuard(child: HomePage()),
         ),
         GetPage(
           name: '/take-picture-page',
-          page: () => const TakePicturePage(),
+          page: () => const TapGuard(child: TakePicturePage()),
         ),
         GetPage(
           name: '/print-page',
-          page: () => const PrintPage(),
+          page: () => const TapGuard(child: PrintPage()),
         )
       ],
-      title: 'Linux Photo Booth',
+      title: 'Ubu4Cut',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
+        // Touch-kiosk sizing: large, finger-friendly buttons everywhere so taps
+        // don't miss. Individual buttons may still override via their own style.
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size(220, 72),
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 18),
+            textStyle: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+          ),
+        ),
+        textButtonTheme: TextButtonThemeData(
+          style: TextButton.styleFrom(
+            minimumSize: const Size(200, 64),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            textStyle: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/homePage.dart
+++ b/lib/pages/homePage.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'dart:io';
+import '../controllers/orientationController.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -83,7 +84,7 @@ class _HomePageState extends State<HomePage> {
                             isSelected: _selectedType == 1,
                             onTap: () => setState(() => _selectedType = 1),
                           ),
-                          SizedBox(width: 20),
+                          SizedBox(width: 28),
                           _buildModeButton(
                             icon: Icons.window,
                             label: '4장',
@@ -119,6 +120,17 @@ class _HomePageState extends State<HomePage> {
                           ),
                         ),
                       ),
+                      const SizedBox(height: 16),
+                      Obx(() {
+                        final oc = Get.find<OrientationController>();
+                        return TextButton.icon(
+                          onPressed: oc.rotate,
+                          icon: const Icon(Icons.screen_rotation),
+                          label: Text(
+                            '화면 회전 ${oc.degrees}° (탭하면 90°)',
+                          ),
+                        );
+                      }),
                     ],
                   ),
                 ),
@@ -139,8 +151,8 @@ class _HomePageState extends State<HomePage> {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 120,
-        height: 120,
+        width: 160,
+        height: 160,
         decoration: BoxDecoration(
           color: isSelected ? Colors.orange[600] : Colors.grey[200],
           borderRadius: BorderRadius.circular(20),
@@ -164,14 +176,14 @@ class _HomePageState extends State<HomePage> {
           children: [
             Icon(
               icon,
-              size: 48,
+              size: 64,
               color: isSelected ? Colors.white : Colors.grey[600],
             ),
-            SizedBox(height: 8),
+            SizedBox(height: 12),
             Text(
               label,
               style: TextStyle(
-                fontSize: 18,
+                fontSize: 22,
                 fontWeight: FontWeight.bold,
                 color: isSelected ? Colors.white : Colors.grey[700],
               ),

--- a/lib/pages/printPage.dart
+++ b/lib/pages/printPage.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
-import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -29,6 +28,7 @@ class PrintPage extends StatefulWidget {
 
 class _PrintPageState extends State<PrintPage> {
   ByteData? _combinedImageData;
+  bool _printing = false;
   final ImageController imageController = Get.find();
 
   @override
@@ -97,10 +97,11 @@ class _PrintPageState extends State<PrintPage> {
               Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
-                  onPressed: () {
-                    _printImage();
-                  },
-                  child: const Text('Print the picture'),
+                  onPressed: (_combinedImageData == null || _printing)
+                      ? null
+                      : _printImage,
+                  child:
+                      Text(_printing ? 'Printing…' : 'Print the picture'),
                 ),
               ),
               Padding(
@@ -122,10 +123,11 @@ class _PrintPageState extends State<PrintPage> {
 
   /// 메모리에서 합성한 PNG를 CUPS `lp`로 직접 인쇄합니다 (로컬 HTTP 서버 없음).
   void _printImage() async {
-    if (_combinedImageData == null) {
-      _showMessage('No image to print');
+    if (_combinedImageData == null || _printing) {
+      if (_combinedImageData == null) _showMessage('No image to print');
       return;
     }
+    setState(() => _printing = true);
 
     File? tempFile;
     try {
@@ -134,7 +136,7 @@ class _PrintPageState extends State<PrintPage> {
       final String baseDir =
           Platform.environment['SNAP_USER_COMMON'] ?? Directory.systemTemp.path;
       tempFile = File(
-          '$baseDir/photo_booth_${DateTime.now().millisecondsSinceEpoch}.png');
+          '$baseDir/ubu4cut_${DateTime.now().millisecondsSinceEpoch}.png');
       await tempFile.writeAsBytes(imageBytes, flush: true);
 
       // CUPS `lp`로 기본 프린터에 인쇄. media/borderless는 스냅 설정(env)에서.
@@ -174,13 +176,19 @@ class _PrintPageState extends State<PrintPage> {
           await tempFile.delete();
         }
       } catch (_) {}
+      if (mounted) setState(() => _printing = false);
     }
   }
 
   /// 사용자에게 메시지를 표시합니다
   void _showMessage(String message) {
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      // Collapse any queued snackbars first: repeated failed prints used to
+      // stack many snackbar animations and could crash Frame's fragile
+      // compositor.
+      final messenger = ScaffoldMessenger.of(context);
+      messenger.clearSnackBars();
+      messenger.showSnackBar(
         SnackBar(
           content: Text(message),
           duration: const Duration(seconds: 3),

--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -207,6 +207,7 @@ class _TakePicturePageState extends State<TakePicturePage>
   }
 
   void _takePicture() {
+    if (_takingPicture) return; // ignore double-taps while a capture runs
     setState(() {
       _countdown = 5;
       _takingPicture = true;

--- a/lib/widgets/tapGuard.dart
+++ b/lib/widgets/tapGuard.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+/// Absorbs pointer input for a short window right after a screen appears.
+///
+/// On a touch kiosk with fast transitions users tend to double-tap; the second
+/// tap "carries over" onto the freshly pushed screen and activates whatever
+/// button is there. Swallowing the first fraction of a second of input on every
+/// new route prevents that.
+///
+/// The window is runtime-tunable via `BOOTH_TAP_GUARD_MS` (milliseconds) so it
+/// can be balanced against perceived input lag without rebuilding — set it to
+/// `0` to disable the guard entirely.
+class TapGuard extends StatefulWidget {
+  final Widget child;
+
+  const TapGuard({Key? key, required this.child}) : super(key: key);
+
+  static Duration get guardDuration {
+    final ms = int.tryParse(Platform.environment['BOOTH_TAP_GUARD_MS'] ?? '');
+    return Duration(milliseconds: (ms == null || ms < 0) ? 300 : ms);
+  }
+
+  @override
+  State<TapGuard> createState() => _TapGuardState();
+}
+
+class _TapGuardState extends State<TapGuard> {
+  bool _absorbing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final d = TapGuard.guardDuration;
+    if (d > Duration.zero) {
+      _absorbing = true;
+      Future.delayed(d, () {
+        if (mounted) setState(() => _absorbing = false);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_absorbing) return widget.child;
+    return AbsorbPointer(absorbing: true, child: widget.child);
+  }
+}

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "linux_photo_booth")
+set(BINARY_NAME "ubu4cut")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.test.linux_photo_booth")
+set(APPLICATION_ID "com.ubu4cut.Ubu4Cut")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "linux_photo_booth");
+    gtk_header_bar_set_title(header_bar, "Ubu4Cut");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "linux_photo_booth");
+    gtk_window_set_title(window, "Ubu4Cut");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: linux_photo_booth
-description: "A new Flutter project."
+name: ubu4cut
+description: "Ubu4Cut — a Flutter photo-booth kiosk for Ubuntu Core + Ubuntu Frame (Raspberry Pi 5)."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 # configure hook: exposes print media as snap configuration.
-#   snap set linux-photo-booth print.media=4x6 print.borderless=true
+#   snap set ubu4cut print.media=4x6 print.borderless=true
 # Defaults target dye-sub photo printers (4x6 borderless). Values are written to
 # $SNAP_DATA/print-config.env, which run-booth sources for the app.
 set -e

--- a/snap/local/desktop/ubu4cut.desktop
+++ b/snap/local/desktop/ubu4cut.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Linux Photo Booth
-Comment=A professional photo booth application for Ubuntu Core
-Exec=linux-photo-booth
+Name=Ubu4Cut
+Comment=Ubu4Cut photo-booth kiosk for Ubuntu Core + Ubuntu Frame
+Exec=ubu4cut
 Terminal=false
 Categories=Graphics;Photography;Utility;
 Keywords=photo;camera;booth;print;event;kiosk;
-StartupWMClass=linux-photo-booth
+StartupWMClass=ubu4cut

--- a/snap/local/run-booth
+++ b/snap/local/run-booth
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Linux Photo Booth launcher — Ubuntu Core (Ubuntu Frame kiosk) + Ubuntu Desktop.
+# Ubu4Cut launcher — Ubuntu Core (Ubuntu Frame kiosk) + Ubuntu Desktop.
 # Wayland-only (Ubuntu Frame and modern desktop sessions are Wayland). The legacy
 # X11 fallback and x86-specific GLX tuning were removed; the `gpu` extension now
 # provides mesa/gpu-2404, so only app-specific GStreamer/GTK runtime env remains.
@@ -80,7 +80,7 @@ echo "Camera: kind=${CAMERA_KIND:-none} device=${CAMERA_DEVICE:-none}"
 
 # Resolve the Flutter binary.
 FLUTTER_BIN=""
-for candidate in "$SNAP/bin/linux_photo_booth" "$SNAP/linux_photo_booth"; do
+for candidate in "$SNAP/bin/ubu4cut" "$SNAP/ubu4cut"; do
     if [ -x "$candidate" ]; then FLUTTER_BIN="$candidate"; break; fi
 done
 if [ -z "$FLUTTER_BIN" ]; then
@@ -95,5 +95,5 @@ if [ -f "$SNAP_DATA/print-config.env" ]; then
     export BOOTH_PRINT_MEDIA BOOTH_PRINT_BORDERLESS
 fi
 
-echo "Starting Linux Photo Booth ($(date)) — $FLUTTER_BIN"
+echo "Starting Ubu4Cut ($(date)) — $FLUTTER_BIN"
 exec "$FLUTTER_BIN" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
-name: linux-photo-booth
+name: ubu4cut
 version: '1.0.0'
-summary: Professional photo booth application for Ubuntu Core
+summary: Ubu4Cut — photo-booth kiosk for Ubuntu Core + Ubuntu Frame
 description: |
   A professional photo booth application designed for Ubuntu Core + Ubuntu Frame
   (kiosk) and Ubuntu Desktop from a single snap.
@@ -43,13 +43,13 @@ layout:
     bind: $SNAP/usr/libexec/libcamera
 
 # Two app entries share one Flutter binary:
-#   - linux-photo-booth        : Ubuntu Desktop launcher (manual, from the app menu)
-#   - linux-photo-booth-kiosk  : Ubuntu Core kiosk daemon (autostarts under Ubuntu Frame)
+#   - ubu4cut        : Ubuntu Desktop launcher (manual, from the app menu)
+#   - ubu4cut-kiosk  : Ubuntu Core kiosk daemon (autostarts under Ubuntu Frame)
 # Both apps use the `gnome` extension: it provides the complete GTK/GLib/pixbuf/
 # fontconfig/xkb/icon/theme runtime (the gnome-46-2404 content snap) + mesa graphics +
 # wayland — everything a Flutter/GTK app needs, wired up by desktop-launch.
 apps:
-  linux-photo-booth:
+  ubu4cut:
     command: bin/run-booth
     extensions: [gnome]
     plugs:
@@ -61,7 +61,7 @@ apps:
       - desktop-legacy
       - gsettings
       - hardware-observe   # libcamera media-device enumeration (sysfs + udev)
-    desktop: usr/share/applications/linux-photo-booth.desktop
+    desktop: usr/share/applications/ubu4cut.desktop
     environment: &booth-env
       FLUTTER_ENGINE_RUNTIME_MODE: release
       FLUTTER_ENGINE_SWITCH_TO_IMPELLER: "0"
@@ -72,7 +72,7 @@ apps:
   # Ubuntu Core kiosk service. `install-mode: disable` prevents a root daemon
   # crash-loop on Ubuntu Desktop (no seat/Wayland at boot); on Ubuntu Core it is
   # explicitly enabled by setup-ubuntu-core.sh via `snap start --enable`.
-  linux-photo-booth-kiosk:
+  ubu4cut-kiosk:
     command: bin/run-booth
     daemon: simple
     install-mode: disable
@@ -131,7 +131,7 @@ parts:
     plugin: dump
     source: snap/local/desktop/
     organize:
-      linux-photo-booth.desktop: usr/share/applications/linux-photo-booth.desktop
+      ubu4cut.desktop: usr/share/applications/ubu4cut.desktop
 
   launcher:
     plugin: dump

--- a/test/image_controller_test.dart
+++ b/test/image_controller_test.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:linux_photo_booth/controllers/imageController.dart';
+import 'package:ubu4cut/controllers/imageController.dart';
 
 void main() {
   group('ImageController', () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:linux_photo_booth/main.dart';
+import 'package:ubu4cut/main.dart';
 
 void main() {
   testWidgets('App launches and shows home page', (WidgetTester tester) async {

--- a/ubuntu-core/build-and-verify.md
+++ b/ubuntu-core/build-and-verify.md
@@ -1,0 +1,76 @@
+# 빌드 & 검증 (Launchpad + 무하드웨어 게이트)
+
+이 macOS 개발 호스트엔 `snapcraft`/`ubuntu-image`가 없고 대상은 Ubuntu Core(빌드 불가)
+이므로, **snap 빌드는 Launchpad**, **이미지/재이미징은 리눅스+SD**로 수행합니다.
+
+## A. Launchpad로 snap 빌드 (로컬 snapcraft 불필요)
+booth 스냅과 (필요 시) 커스텀 gadget 스냅 모두 동일 방식.
+1. 레포를 git 원격(GitHub/Launchpad)에 푸시.
+2. https://launchpad.net → *Snap packages* → **Create snap package**:
+   - Source: 해당 git 저장소/브랜치
+   - Built for: **arm64, amd64**
+   - Automatically upload to store: (선택)
+3. **Request builds** → 빌드된 `.snap` 다운로드.
+
+대안(리눅스 + snapcraft가 있을 때): `snapcraft remote-build --launchpad-accept-public-upload`
+(모든 platforms 아키텍처를 Launchpad 팜에서 빌드). `--use-lxd`/`--destructive-mode`는
+M1(arm64)에서 amd64를 만들지 못하므로 사용하지 않음.
+
+## B. 무하드웨어 검증 (리눅스/VM)
+```
+snapcraft lint <booth>.snap                 # 라이브러리/링커 린트
+review-tools.snap-review <booth>.snap        # 스토어급 confinement/인터페이스 검사
+sudo snap install --dangerous <booth>.snap
+snap connections ubu4cut                     # camera/cups/wayland 해소 확인 (cups-control 없어야)
+# 데스크톱/VM에서 키오스크 daemon 렌더 확인:
+sudo snap install ubuntu-frame
+frame-it ubu4cut.ubu4cut-kiosk
+```
+확인 포인트:
+- 이중 앱 엔트리(`ubu4cut`, `ubu4cut-kiosk`) 존재.
+- 미사용 plug/슬롯 없음(network/network-bind/raw-usb/audio-playback/cups-control/com.test dbus 제거).
+- `frame-it`로 daemon 앱이 Frame 안에서 렌더.
+
+## C. grade devel → stable
+`snap/snapcraft.yaml`의 `grade: devel`은 검증 전 안전값입니다. **B**의 무하드웨어 게이트와
+**RPi5 수용 체크리스트**가 모두 통과한 뒤에만 `grade: stable`로 올려 재빌드하세요
+(devel 스냅은 stable/candidate 채널 릴리스 불가).
+
+## D. 스토어 자동연결 vs 사이드로드
+- 스토어 설치 시 `cups`는 auto-connect.
+- `--dangerous` 사이드로드는 전제 snap 자동설치/자동연결이 없으므로
+  `setup-ubuntu-core.sh`가 cups/printer-app/인터페이스를 명시적으로 처리.
+
+## E. 검증된 로컬 Docker 빌드 (arm64, Launchpad 불필요) — 실제 통과함
+
+아래 절차로 **arm64 booth 스냅을 로컬에서 빌드·리뷰 통과**시켰습니다(EXIT=0, `review-tools.snap-review: pass`). Apple Silicon(arm64) + Docker에서 재현 가능. amd64는 amd64 호스트/컨테이너 또는 Launchpad로.
+
+```bash
+# 1) systemd(PID1) 컨테이너 (snapd는 systemd 필요)
+docker run -d --name sc-build --privileged --cgroupns=host \
+  --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+  ubuntu:24.04 bash -c \
+  "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq systemd systemd-sysv snapd; exec /sbin/init"
+
+# 2) snapd + snapcraft
+docker exec sc-build bash -c \
+  "systemctl enable --now snapd.socket snapd.service && \
+   snap wait system seed.loaded && snap install snapcraft --classic"
+
+# 3) 소스 주입 (작업트리 그대로; 대용량/불필요 제외)
+tar --exclude=./*.snap --exclude=./macos --exclude=./build --exclude=./.git \
+  -czf - . | docker exec -i sc-build bash -c "rm -rf /build && mkdir /build && tar -xzf - -C /build"
+
+# 4) 빌드 + 검증
+docker exec sc-build bash -c \
+  "cd /build && export PATH=/snap/bin:\$PATH && \
+   snapcraft expand-extensions >/dev/null && \
+   snapcraft --destructive-mode && \
+   cp *.snap /root/ && cd /root && review-tools.snap-review *.snap"
+
+# 5) 산출물 회수
+docker cp sc-build:/build/ubu4cut_1.0.0_arm64.snap ./
+```
+
+결과물 `./ubu4cut_1.0.0_arm64.snap`(약 116MB, `grade: devel`)은 Pi에 사이드로드 가능:
+`sudo snap install --dangerous ubu4cut_1.0.0_arm64.snap` (그 뒤 `ubuntu-core/setup-ubuntu-core.sh`).

--- a/ubuntu-core/build-image.sh
+++ b/ubuntu-core/build-image.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Build a custom Ubuntu Core 26 image for the RPi5 photo booth.
+#
+# WHY custom (vs the stock cdimage Core 26 image): this model is grade:dangerous
+# with `system-user-authority: "*"`, which lets you inject a LOCAL-LOGIN user via a
+# USB `auto-import.assert` (see make-auto-import.sh) — no console-conf, no
+# first-boot network. That is what unblocks the Pi5 when the onboard Wi-Fi (a Core
+# 26 / kernel 7.0 regression) can't scan at console-conf: you log in on the Pi's
+# own touch monitor (KMS works on Core 26) and fix Wi-Fi from a real shell.
+#
+# The Core 26 STOCK `pi` gadget already ships full KMS + camera_auto_detect, so no
+# custom gadget is built here. (camera-csi custom-device slot = optional
+# iteration 2, see gadget-camera-kms.md.)
+#
+# Runs in a privileged systemd Docker container (Apple Silicon / arm64 OK).
+# Prereq: a SIGNED ./ubu4cut.model (see sign-model.sh) + Docker with ~8GB free.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MODEL="${MODEL:-${REPO_ROOT}/ubu4cut.model}"
+CONTAINER="${CONTAINER:-uc-imgbuild}"
+
+[ -f "$MODEL" ] || { echo "ERROR: signed model not found at $MODEL — run ubuntu-core/sign-model.sh first" >&2; exit 1; }
+
+echo "== 1/4 systemd + snapd container ($CONTAINER) =="
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$CONTAINER" --privileged --cgroupns=host \
+    --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    ubuntu:24.04 bash -c \
+    "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq systemd systemd-sysv snapd xz-utils && exec /sbin/init"
+  echo "   waiting for container systemd (apt install + init boot)…"
+  for _ in $(seq 1 60); do
+    state=$(docker exec "$CONTAINER" systemctl is-system-running 2>/dev/null || true)
+    case "$state" in running|degraded|starting|maintenance) break ;; esac
+    sleep 5
+  done
+fi
+
+echo "== 2/4 snapd + ubuntu-image =="
+docker exec "$CONTAINER" bash -c \
+  "systemctl enable --now snapd.socket snapd.service && snap wait system seed.loaded && snap install ubuntu-image --classic"
+
+echo "== 3/4 ubuntu-image (stock Core 26 snaps) =="
+docker cp "$MODEL" "$CONTAINER":/root/ubu4cut.model
+docker exec -i "$CONTAINER" bash -s <<'EOS'
+set -e
+export PATH=/snap/bin:$PATH
+rm -rf /root/out && mkdir -p /root/out
+ubuntu-image snap /root/ubu4cut.model --validation=ignore -O /root/out
+cd /root/out
+IMG=$(ls -1 *.img | head -1)
+echo "built image: $IMG"
+xz -T0 -v "$IMG"
+ls -la
+EOS
+
+echo "== 4/4 copy image out =="
+mkdir -p "${REPO_ROOT}/out"
+docker cp "$CONTAINER":/root/out/. "${REPO_ROOT}/out/"
+ls -la "${REPO_ROOT}/out/"
+echo
+echo "DONE -> ${REPO_ROOT}/out/*.img.xz"
+echo "Next: flash a SPARE SD (flash-and-verify.md), boot with the USB auto-import.assert, log in locally."

--- a/ubuntu-core/flash-and-verify.md
+++ b/ubuntu-core/flash-and-verify.md
@@ -1,0 +1,91 @@
+# RPi5 부스: 커스텀 Core 26 이미지 (로컬 로그인) — 네트워크 없이 첫 부팅 뚫기
+
+## 왜 이 경로 (실측 결론)
+| | KMS(디스플레이) | 온보드 WiFi |
+|---|---|---|
+| Core 24 (커널 6.8) | ❌ 레거시 FB 고정 | ✅ |
+| Core 26 (커널 7.0) | ✅ | ❌ 스캔 죽음 (kernel 7.0 brcmfmac 리그레션) |
+
+Core 26은 KMS를 고쳤지만 **온보드 WiFi 스캔이 죽어**, stock 이미지의 console-conf가 네트워크를 못 잡아 첫 부팅에서 막힌다.
+**해결:** 커스텀 Core 26 모델(`grade: dangerous` + `system-user-authority: "*"`)로 이미지를 굽고, USB의
+`auto-import.assert`로 **로컬 로그인 계정을 자동 생성**한다 → console-conf 없이 **파이 앞에서(터치 모니터 + Varmilo
+키보드, KMS 정상) 로그인** → 쉘에서 WiFi를 직접 수리. (계정에 SSH키도 심어, WiFi 살아나면 `ssh ubu4cut@<ip>`도 됨)
+
+## 준비물
+예비 SD · **FAT32/ext4 USB 스틱 1개**(auto-import용) · USB 키보드 · 터치 모니터 · Ubuntu One 계정(이미 있음) · Docker
+
+## 아티팩트 (레포에 준비됨)
+- `ubuntu-core/model/ubu4cut-core-26-pi-arm64.model.json` — 커스텀 dangerous 모델 (console-conf 제외)
+- `ubuntu-core/system-user.json` — 로컬 유저 템플릿 (SSH 공개키 이미 임베드)
+- `ubuntu-core/sign-model.sh` · `build-image.sh` · `make-auto-import.sh`
+
+## 절차
+### 0) 컨테이너 + 스토어 로그인/키 등록 (인터랙티브 — 당신 터미널)
+```bash
+# 컨테이너 만들고 snapcraft 설치 (build-image.sh가 만드는 것과 동일)
+docker run -d --name uc-imgbuild --privileged --cgroupns=host --tmpfs /run --tmpfs /run/lock \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw ubuntu:24.04 bash -c \
+  "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq systemd systemd-sysv snapd xz-utils openssl && exec /sbin/init"
+sleep 60
+docker exec uc-imgbuild bash -c "systemctl enable --now snapd.socket && snap wait system seed.loaded && snap install snapcraft --classic && snap install ubuntu-image --classic"
+
+# 스토어 로그인 + 서명키 등록 (당신 Ubuntu One — 인터랙티브). snapcraft는 /snap/bin 전체경로로!
+docker exec -it uc-imgbuild snap login
+docker exec -it uc-imgbuild /snap/bin/snapcraft login
+docker exec -it uc-imgbuild /snap/bin/snapcraft create-key ubu4cut   # 패스프레이즈: 그냥 Enter(빈값) 가능
+docker exec -it uc-imgbuild /snap/bin/snapcraft register-key ubu4cut
+docker exec uc-imgbuild /snap/bin/snapcraft whoami                       # developer-id 확인 (= BRAND_ID)
+
+# 레포의 서명 자료를 컨테이너로
+docker cp ubuntu-core uc-imgbuild:/root/ubuntu-core
+```
+
+### 1) 모델 서명 → ubu4cut.model
+```bash
+docker exec -e BRAND_ID=<developer-id> -e KEY_NAME=ubu4cut uc-imgbuild bash -lc \
+  'cd /root && ubuntu-core/sign-model.sh ubuntu-core/model/ubu4cut-core-26-pi-arm64.model.json > ubu4cut.model && echo signed'
+docker cp uc-imgbuild:/root/ubu4cut.model ./ubu4cut.model
+```
+
+### 2) 이미지 빌드 → out/*.img.xz
+```bash
+ubuntu-core/build-image.sh            # 컨테이너(uc-imgbuild) 재사용, ubuntu-image로 빌드
+```
+
+### 3) auto-import.assert 생성 (로컬 비번 설정) → USB
+```bash
+docker exec -it -e BRAND_ID=<developer-id> -e EMAIL=<ubuntu-one-이메일> -e KEY_NAME=ubu4cut uc-imgbuild \
+  bash -lc 'cd /root && ubuntu-core/make-auto-import.sh ubuntu-core/system-user.json'   # 로컬 로그인 비번 입력
+docker cp uc-imgbuild:/root/auto-import.assert ./auto-import.assert
+# USB 스틱(FAT32) 루트에 복사:
+cp ./auto-import.assert /Volumes/<USB이름>/auto-import.assert && sync
+```
+
+### 4) SD 굽기 + 부팅 (USB 꽂은 채로)
+```bash
+diskutil list                         # SD 확인 (예: /dev/disk5) — 내장 disk0 아님!
+diskutil unmountDisk /dev/disk5
+xzcat out/*.img.xz | sudo dd of=/dev/rdisk5 bs=4m
+sync && diskutil eject /dev/disk5
+```
+SD를 파이에 꽂고, **auto-import.assert USB 스틱도 함께 꽂은 채** 전원 ON.
+
+### 5) 로컬 로그인 (네트워크 불필요)
+- 첫 부팅 후 **몇 분** 뒤 유저 생성됨(터치 모니터에 로그인 프롬프트). USB는 그 뒤 빼도 됨.
+- 로그인: **username `ubu4cut`** + (3단계에서 정한 비번). → **쉘 획득** (KMS 덕에 화면 정상).
+
+### 6) 쉘에서 WiFi 수리 → 온라인
+```bash
+sudo rfkill list                                   # wifi soft/hard block?
+sudo rfkill unblock wifi
+sudo iw reg set KR ; sudo iw reg get
+dmesg | grep -i brcmfmac                            # 펌웨어/드라이버 에러 원인
+sudo snap install network-manager                  # (온라인 전이라 실패하면, 아래로)
+# 온보드가 끝내 안 되면 USB WiFi 동글(다른 칩셋) 꽂고 nmcli로 연결
+ip -brief addr ; ip route                           # IP 확인
+```
+IP 나오면 나한테 알려주면 SSH로 이어받아 부스 설치까지 마무리.
+
+## 참고
+- 온보드 WiFi가 하드 리그레션이면 config로 못 고침 → **USB WiFi 동글** 또는 이더넷으로. (로컬 쉘이 있으니 진단·전환 자유로움)
+- KMS/카메라는 Core 26 stock 게 이미 동작 → `ls /dev/dri/card0`, `rp1-cfe` 확인 후 `setup-ubuntu-core.sh`로 부스.

--- a/ubuntu-core/gadget-camera-kms.md
+++ b/ubuntu-core/gadget-camera-kms.md
@@ -1,0 +1,109 @@
+# CSI 카메라 + 풀 KMS 활성화 (커스텀 gadget/모델/재이미징)
+
+> ⚠️ **실측 정정 2026-07-18:** Ubuntu Core **24**는 이 Pi5에서 풀 KMS가 안 된다(부트 펌웨어가 Pi5를
+> 레거시 FB로 고정 — config.txt 오버레이(vc4-kms-v3d/-pi5/disable_fw_kms_setup)로 불가, 4회 재부팅 실증).
+> **디스플레이 해법 = stock Ubuntu Core 26** (gadget이 이미 vc4-kms-v3d + disable_fw_kms_setup +
+> camera_auto_detect 탑재) → `ubuntu-core/flash-and-verify.md` 옵션 A. 아래 커스텀 gadget 절차는
+> `camera-csi` custom-device 슬롯이 필요할 때(옵션 B)만, 그때도 **Core 26(branch 26 / base core26)** 로 재타게팅.
+
+> **자동화됨 (실측 2026-07-18, 이 레포 대상 기기 기준).** 아래 수동 절차는 배경 설명이고,
+> 실제 실행은 리포의 스크립트로 대체된다:
+> - `ubuntu-core/gadget/config.txt` — fkms→풀KMS + `camera_auto_detect=1` (`configs/config.txt` 드롭인)
+> - `ubuntu-core/gadget/camera-csi-slot.yaml` — `camera-csi` custom-device 슬롯 (**snapcraft.yaml**에 append)
+> - `ubuntu-core/sign-model.sh` → `ubuntu-core/build-image.sh` → `ubuntu-core/flash-and-verify.md`
+>
+> 실측 확인: 모델 `ubuntu-core-24-pi-arm64` **grade=signed**(→ dangerous 커스텀 모델 필수),
+> config.txt가 `vc4-fkms-v3d`(Pi5에선 `/dev/fb0`만 뜨고 `/dev/dri` 없음), v4l 노드에 `rp1-cfe`
+> 없음(ISP `pispbe-*` + HEVC `rpivid`만). 커널 `overlays/`엔 `vc4-kms-v3d`/`vc4-kms-v3d-pi5`,
+> `imx708`/`imx219`/`ov5647` 등이 **이미 존재** → config.txt 두 줄만 고치면 열린다.
+
+대상: `ubuntu-core-24-pi-arm64` (stock signed, brand Canonical). 연결 카메라는 **CSI**이며 stock
+gadget(fkms + 카메라 미활성)에서 인식되지 않는다.
+
+## 왜 필요한가 (실측 근거)
+- gadget 소유 `config.txt`에 `camera_auto_detect`/센서 `dtoverlay` **없음** → `rp1-cfe`/센서 subdev 미생성.
+- 그래픽이 `dtoverlay=vc4-fkms-v3d`(가짜 KMS) → Pi5에선 DRM/KMS 카드 미생성, Ubuntu Frame(Wayland)은 **`vc4-kms-v3d`(풀 KMS)** 필요.
+- `snap get -d pi` = `{}`. **`snap set pi pi-config.*`는 고정 허용목록**(hdmi_*, disable_overscan, display_rotate, gpu_mem, framebuffer_* 등)만 지원 → `camera_auto_detect`/임의 `dtoverlay`는 **런타임 설정 불가**.
+- stock **signed 모델은 외부 gadget으로 교체 불가** → 자체 dev key **커스텀(dangerous) 모델 + 재이미징** 필요.
+
+## 목표 config.txt 라인 (→ `ubuntu-core/gadget/config.txt`에 반영됨)
+```
+# 풀 KMS (Wayland/Ubuntu Frame; Pi5는 fkms 미지원). /dev/dri/card0 생성.
+dtoverlay=vc4-kms-v3d,cma-256
+# 카메라 자동 감지 (또는 정확 센서: dtoverlay=imx708 등). start_x=1/gpu_mem은 쓰지 말 것(구 MMAL 스택).
+camera_auto_detect=1
+```
+정확 센서 모델은 활성화 후 `cam --list`(libcamera-tools) 또는 `/sys/class/video4linux/*/name`(rp1-cfe 등장 확인)으로 식별.
+
+## 절차
+### 1) (먼저 시도) gadget 설정 경로 — 대개 불가
+```
+sudo snap set pi pi-config.camera-auto-detect=1   # 허용목록 밖이면 실패 → 커스텀 gadget으로
+```
+
+### 2) 커스텀 pi gadget
+```
+git clone https://github.com/canonical/pi-gadget -b 24   # Ubuntu Core 24 (모델 채널과 일치). classic-24는 Ubuntu Classic용.
+```
+- 부트 config.txt: 레포의 `ubuntu-core/gadget/config.txt`로 `configs/config.txt`를 교체.
+- **custom-device 슬롯은 `snapcraft.yaml`의 top-level `slots:`에 추가한다 (gadget.yaml 아님).**
+  snapcraft-빌드 gadget은 인터페이스 슬롯을 snapcraft.yaml에 선언하고, gadget.yaml은 볼륨/파티션
+  레이아웃 전용이다. 내용 = `ubuntu-core/gadget/camera-csi-slot.yaml`:
+```yaml
+slots:
+  camera-csi:
+    interface: custom-device
+    custom-device: camera-csi
+    devices:
+      - /dev/media[0-9]*
+      - /dev/v4l-subdev[0-9]*
+      - /dev/video[0-9]*
+    read-devices:
+      - /dev/rp1-cfe*
+```
+- gadget snap 빌드: 리눅스/컨테이너의 `snapcraft`. `build-image.sh`가 clone→패치→빌드까지 자동 수행.
+
+### 3) 커스텀 모델 assertion (→ `ubuntu-core/model/ubu4cut-core-24-pi-arm64.model.json`)
+- **개발/반복**: `grade: dangerous` 모델(로컬 unasserted gadget 부팅 허용). 단 **모델 서명 자체는 필요** —
+  무료 Ubuntu One 개발자 계정 + `snapcraft register-key`로 등록한 dev key로 `snap sign`(→ `sign-model.sh`).
+- **프로덕션**: 전용 brand 계정 key로 서명(grade signed).
+- 모델에 커스텀 gadget(+ pi-kernel/core24/snapd/console-conf)을 명시. dangerous라 gadget은 로컬
+  `--snap pi_*.snap`으로 오버라이드(id 불필요).
+
+### 4) 이미지 빌드 + 재이미징 → `ubuntu-core/build-image.sh` + `flash-and-verify.md`
+```bash
+# 서명된 모델 생성:
+BRAND_ID=<developer-id> KEY_NAME=ubu4cut \
+  ubuntu-core/sign-model.sh ubuntu-core/model/ubu4cut-core-24-pi-arm64.model.json > ubu4cut.model
+# 커스텀 gadget 빌드 + ubuntu-image (컨테이너; Apple Silicon OK) -> out/*.img.xz:
+ubuntu-core/build-image.sh
+# 예비 SD에 굽기 (원본 롤백 이미지 보관 필수):
+xzcat out/*.img.xz | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync   # macOS는 flash-and-verify.md
+```
+
+### 5) 검증 (재이미징 후 실기)
+```
+ls /dev/dri/                                 # 풀 KMS: card0 존재
+for f in /sys/class/video4linux/*/name; do cat $f; done | grep -i cfe   # rp1-cfe 등장
+snap connections ubu4cut                     # camera/wayland/cups 연결
+```
+
+### 6) (선택 / iteration 2) 부스 스냅에 CSI custom-device 플러그
+표준 `camera` 인터페이스(/dev/video* + /dev/media*)로 libcamera CSI가 부족할 때만. `snap/snapcraft.yaml`에
+추가하고 부스 스냅을 **재빌드·재사이드로드**(재이미징 불필요; gadget엔 슬롯이 이미 있음):
+```yaml
+# top-level (앱의 plugs 목록에도 `camera-csi` 추가)
+plugs:
+  camera-csi:
+    interface: custom-device
+    custom-device: camera-csi
+```
+연결: `sudo snap connect ubu4cut:camera-csi pi:camera-csi`.
+⚠️ custom-device는 super-privileged라 `review-tools.snap-review`가 snap-declaration을 요구한다 →
+스토어 배포 전까지는 사이드로드(devel) 전용. 현재 무하드웨어 게이트의 review-tools 통과를 깨지 않으려면
+이 플러그는 **카메라 컨파인먼트가 실제로 필요할 때** 추가할 것.
+
+## 리스크 / 주의
+- 재이미징은 **기기 전체 초기화** → 예비 SD 선검증 + 원본 롤백 이미지 보관 필수.
+- dev key 서명 실수 시 부팅 불가 → 개발은 grade=dangerous 모델로.
+- 커스텀 gadget/kernel/base rev는 core24와 정합해야 함.

--- a/ubuntu-core/gadget/camera-csi-slot.yaml
+++ b/ubuntu-core/gadget/camera-csi-slot.yaml
@@ -1,0 +1,17 @@
+# Appended by ubuntu-core/build-image.sh to the pi gadget snapcraft.yaml's `slots:`.
+# (The pi gadget declares its interface slots in snapcraft.yaml; gadget.yaml holds
+# only the volume/partition layout.)
+#
+# CSI capture pipeline for libcamera on the Pi (RP1 CFE front-end + PiSP ISP +
+# sensor subdevs). The standard snapd `camera` interface only grants /dev/video*
+# and /dev/media*; libcamera on the Pi additionally needs the v4l subdevices and
+# the rp1-cfe front-end node, hence this custom-device slot. Harmless if unused.
+  camera-csi:
+    interface: custom-device
+    custom-device: camera-csi
+    devices:
+      - /dev/media[0-9]*
+      - /dev/v4l-subdev[0-9]*
+      - /dev/video[0-9]*
+    read-devices:
+      - /dev/rp1-cfe*

--- a/ubuntu-core/gadget/config.txt
+++ b/ubuntu-core/gadget/config.txt
@@ -1,0 +1,63 @@
+[all]
+kernel=kernel.img
+cmdline=cmdline.txt
+initramfs initrd.img followkernel
+os_prefix=
+
+[pi4]
+max_framebuffers=2
+arm_boost=1
+
+[all]
+# Enable the audio output, I2C and SPI interfaces on the GPIO header. As these
+# parameters related to the base device-tree they must appear *before* any
+# other dtoverlay= specification
+dtparam=audio=on
+dtparam=i2c_arm=on
+dtparam=spi=on
+
+# Comment out the following line if the edges of the desktop appear outside
+# the edges of your display
+disable_overscan=1
+
+# If you have issues with audio, you may try uncommenting the following line
+# which forces the HDMI output into HDMI mode instead of DVI (which doesn't
+# support audio output)
+#hdmi_drive=2
+
+# Enable the serial pins
+enable_uart=1
+
+[cm4]
+# Enable the USB2 outputs on the IO board (assuming your CM4 is plugged into
+# such a board)
+dtoverlay=dwc2,dr_mode=host
+
+[all]
+
+# --- Ubu4Cut customization (upstream shipped: vc4-fkms-v3d,cma-128) ---
+# FULL KMS (real DRM/KMS). Required by Ubuntu Frame (Wayland), and mandatory on
+# the Raspberry Pi 5, which does NOT support the legacy "fake" KMS. This is what
+# creates /dev/dri/card0 so the kiosk compositor has a display backend to render
+# on. On the Pi 5 the firmware maps this to vc4-kms-v3d-pi5.dtbo automatically.
+# cma-256 reserves contiguous memory for display + CSI camera buffers (raise to
+# cma-512 if libcamera reports buffer-allocation failures at high resolution).
+dtoverlay=vc4-kms-v3d,cma-256
+
+# Auto-detect a CSI camera sensor and load the matching overlay for libcamera
+# (imx708 / imx219 / imx477 / ov5647 / ... are all present in the kernel's
+# overlays/ directory). This is what makes the rp1-cfe front-end + sensor
+# subdevs appear.
+# NOTE: do NOT also set start_x=1 / gpu_mem — those enable the obsolete firmware
+# (MMAL) camera stack, which conflicts with libcamera + full KMS.
+camera_auto_detect=1
+
+# Prior versions of Ubuntu Core customized the on-board LEDs so that the green
+# ACT LED was a heartbeat, and the red PWR LED represented SD card activity.
+# Uncomment the following lines if you wish to restore these customizations
+#dtparam=act_led_trigger=heartbeat
+#dtparam=pwr_led_trigger=mmc0
+
+# Config settings specific to arm64
+arm_64bit=1
+dtoverlay=dwc2

--- a/ubuntu-core/install-ubuntu-core.md
+++ b/ubuntu-core/install-ubuntu-core.md
@@ -1,502 +1,221 @@
-# Ubuntu Core Advanced Installation Guide
+# Ubuntu Core — Advanced Install & Operations (Ubu4Cut)
 
-This guide provides detailed instructions for advanced Ubuntu Core setup and configuration for the Linux Photo Booth application.
+This guide covers day-2 setup and operations for the **Ubu4Cut** kiosk on Ubuntu Core /
+Raspberry Pi 5. It complements the quick start in the top-level [`README.md`](../README.md)
+and the task-specific guides in this directory — it does **not** repeat the imaging or
+signing steps, it points to them.
 
-## Prerequisites
+> The booth ships as a single snap with two app entries: `ubu4cut` (desktop launcher) and
+> `ubu4cut-kiosk` (Ubuntu Core daemon). It runs `grade: devel` / `confinement: devmode`
+> because the Pi 5 CSI camera needs libcamera access to `/dev/media*` that the strict
+> `camera` interface does not grant — see [`gadget-camera-kms.md`](gadget-camera-kms.md).
 
-Before starting, ensure you have:
-- Raspberry Pi 5 (4GB RAM minimum, 8GB recommended)
-- 32GB+ MicroSD card (Class 10 recommended)
-- USB camera (Logitech C920 or compatible)
-- Touch screen display
-- Network connection (WiFi or Ethernet)
-- Ubuntu One account
+## Documentation map
 
-## Ubuntu Core Image Preparation
+| You want to… | Read |
+|---|---|
+| Build the snap (Launchpad/Docker) + no-hardware gate | [`build-and-verify.md`](build-and-verify.md) |
+| Flash a custom Core 26 image + rescue onboard Wi-Fi | [`flash-and-verify.md`](flash-and-verify.md) |
+| Enable the CSI camera + full KMS (custom gadget/model) | [`gadget-camera-kms.md`](gadget-camera-kms.md) |
+| Wire up Frame/CUPS/kiosk in one shot | [`setup-ubuntu-core.sh`](setup-ubuntu-core.sh) |
+| Sign off on real hardware | [`rpi5-acceptance-checklist.md`](rpi5-acceptance-checklist.md) |
 
-### Download Ubuntu Core Image
+## 1. Prerequisites
+
+- Raspberry Pi 5 (4 GB RAM minimum, 8 GB recommended)
+- 16 GB+ microSD (Class 10 / A1) — **plus a spare SD** for staging image changes
+- A camera: a USB UVC webcam **or** a Raspberry Pi CSI camera on the ribbon connector
+- A touch display (the booth UI is touch-first)
+- Network (Ethernet, or Wi-Fi — note the Pi 5 Wi-Fi caveat below)
+- A free Ubuntu One / snapcraft developer account (for signing a custom model)
+
+## 2. Getting an image onto the Pi
+
+The Pi 5 forces a trade-off between display and onboard Wi-Fi:
+
+| | Full KMS (Ubuntu Frame needs it) | Onboard Wi-Fi |
+|---|---|---|
+| **Core 24** (kernel 6.8) | ❌ pinned to legacy framebuffer | ✅ |
+| **Core 26** (kernel 7.0) | ✅ | ❌ brcmfmac scan regression |
+
+A stock Core 24 image will **not** drive the Pi 5 display under Ubuntu Frame, and a stock
+Core 26 image gets stuck at console-conf because onboard Wi-Fi can't scan. The supported path
+is therefore a **custom Core 26 image** with a local-login user (log in on the Pi's own touch
+monitor, then fix networking from a shell):
+
+- Build/flash the image: **[`flash-and-verify.md`](flash-and-verify.md)**.
+- Enable the CSI camera + full KMS via the gadget's `config.txt`
+  (`camera_auto_detect=1`, `dtoverlay=vc4-kms-v3d`): **[`gadget-camera-kms.md`](gadget-camera-kms.md)**.
+
+> Re-imaging wipes the device. Always stage on a spare SD and keep a rollback image.
+
+## 3. SSH access
+
+The custom Core 26 image embeds an SSH key in the `ubu4cut` local-login user
+(see [`system-user.json`](system-user.json)). Once networking is up:
 
 ```bash
-# Download the latest Ubuntu Core 24.04 LTS image
-wget https://cdimage.ubuntu.com/ubuntu-core/24/stable/current/ubuntu-core-24-arm64+raspi.img.xz
-
-# Verify download integrity
-wget https://cdimage.ubuntu.com/ubuntu-core/24/stable/current/SHA256SUMS
-sha256sum -c SHA256SUMS
-
-# Extract the image
-xz -d ubuntu-core-24-arm64+raspi.img.xz
+ssh ubu4cut@<device-ip>
 ```
 
-### Flash Image to SD Card
+To add your own key on a running device:
 
 ```bash
-# Identify your SD card device
-lsblk
-
-# Flash the image (replace /dev/sdb with your SD card device)
-sudo dd if=ubuntu-core-24-arm64+raspi.img of=/dev/sdb bs=4M status=progress conv=fsync
-
-# Verify the flash
-sudo dd if=/dev/sdb of=/tmp/verify.img bs=4M count=1000
-diff ubuntu-core-24-arm64+raspi.img /tmp/verify.img
+ssh-keygen -t ed25519 -C "you@example.com"          # on your workstation, if needed
+ssh-copy-id -i ~/.ssh/id_ed25519.pub ubu4cut@<device-ip>
 ```
 
-## Initial Ubuntu Core Setup
+## 4. Install & wire the booth
 
-### First Boot Configuration
-
-1. **Insert SD card into Raspberry Pi and power on**
-2. **Connect to WiFi network** during initial setup
-3. **Create Ubuntu One account** if you don't have one
-4. **Note the device IP address** for SSH access
-
-### SSH Access Setup
+The one-shot path is [`setup-ubuntu-core.sh`](setup-ubuntu-core.sh) (installs Ubuntu Frame,
+CUPS, a dye-sub Printer Application, sideloads the booth if a local `.snap` is present,
+connects interfaces, and enables the kiosk daemon):
 
 ```bash
-# Generate SSH key pair (on your development machine)
-ssh-keygen -t ed25519 -C "your-email@example.com"
-
-# Copy public key to Ubuntu Core device
-ssh-copy-id -i ~/.ssh/id_ed25519.pub ubuntu@<device-ip>
-
-# Test SSH connection
-ssh ubuntu@<device-ip>
+sudo ./ubuntu-core/setup-ubuntu-core.sh
 ```
 
-## Advanced System Configuration
-
-### Network Configuration
+The equivalent manual steps:
 
 ```bash
-# Configure static IP (optional)
-sudo nano /etc/netplan/50-cloud-init.yaml
-
-# Apply network configuration
-sudo netplan apply
-
-# Test network connectivity
-ping -c 3 8.8.8.8
-```
-
-### System Updates
-
-```bash
-# Check for system updates
-sudo snap refresh --list
-
-# Update all snaps
-sudo snap refresh
-
-# Check system status
-snap list
-snap services
-```
-
-### Hardware Optimization
-
-```bash
-# Check hardware information
-lscpu
-free -h
-df -h
-lsusb
-lspci
-
-# Monitor system resources
-htop
-```
-
-## Ubuntu Frame Advanced Configuration
-
-### Frame Installation and Setup
-
-```bash
-# Install Ubuntu Frame
+# Compositor (Ubuntu Frame is the Wayland compositor daemon):
 sudo snap install ubuntu-frame
+sudo snap set ubuntu-frame daemon=true        # valid Frame key — NOT daemon.command
 
-# Configure Frame for optimal performance
-sudo snap set ubuntu-frame daemon.enable=true
-sudo snap set ubuntu-frame daemon.restart-condition=always
-sudo snap set ubuntu-frame daemon.restart-delay=10s
-
-# Set display configuration
-sudo snap set ubuntu-frame daemon.environment="DISPLAY=:0 WAYLAND_DISPLAY=wayland-0"
-```
-
-### Display Configuration
-
-```bash
-# Check display information
-echo $DISPLAY
-echo $WAYLAND_DISPLAY
-
-# Configure display rotation (if needed)
-sudo snap set ubuntu-frame daemon.environment="DISPLAY=:0 WAYLAND_DISPLAY=wayland-0 XDG_SESSION_TYPE=wayland"
-
-# Test display
-sudo snap restart ubuntu-frame
-```
-
-### Touch Screen Calibration
-
-```bash
-# Install calibration tools
-sudo snap install xinput-calibrator
-
-# Run calibration
-xinput_calibrator
-
-# Save calibration data
-sudo cp /etc/X11/xorg.conf.d/99-calibration.conf /etc/X11/xorg.conf.d/99-calibration.conf.backup
-```
-
-## CUPS Advanced Configuration
-
-### CUPS Installation and Setup
-
-```bash
-# Install CUPS
+# Printing stack:
 sudo snap install cups
+sudo snap install gutenprint-printer-app      # driverless-IPP for the dye-sub
 
-# Enable CUPS web interface
-sudo snap set cups interface.enable=true
+# The booth (store or sideload):
+sudo snap install ubu4cut                     # or: sudo snap install --dangerous ubu4cut_*.snap
 
-# Connect USB printer interface
-sudo snap connect cups:usb-control
-sudo snap connect cups:network-control
+# Interfaces (sideloads do NOT auto-connect; the store auto-connects cups):
+sudo snap connect ubu4cut:camera
+sudo snap connect ubu4cut:cups cups:cups
+sudo snap connect ubu4cut:wayland
 
-# Start CUPS service
-sudo snap start cups
+# The kiosk daemon ships install-mode:disable, so enable it explicitly:
+sudo snap start --enable ubu4cut.ubu4cut-kiosk
 ```
 
-### Printer Configuration
+The booth kiosk is a **daemon inside the booth snap**, not a command handed to Ubuntu Frame.
+There is no `snap set ubuntu-frame daemon.command=…` step.
+
+## 5. Display (Ubuntu Frame / Wayland)
+
+Ubuntu Frame owns the display server; the booth just renders into it.
 
 ```bash
-# List available printers
-lpstat -p
-
-# Set default printer
-lpoptions -d <printer-name>
-
-# Configure printer settings
-lpoptions -p <printer-name> -o media=4x6 -o print-quality=5
-
-# Test printer
-echo "Test print" | lp -d <printer-name>
+ls /dev/dri/card0                 # full KMS present? (required)
+snap services ubuntu-frame        # Frame active?
+echo "$WAYLAND_DISPLAY"           # wayland-0 under the kiosk
+snap restart ubuntu-frame         # re-apply Frame changes
 ```
 
-### CUPS Web Interface
+- **Orientation:** rotate the UI **in-app** with `BOOTH_PORTRAIT=1` (and
+  `BOOTH_PORTRAIT_TURNS=1|3`). Do not rotate the Frame output — display rotation breaks
+  touch grab/mapping on Frame's Mir, which is why the booth rotates its widget tree instead.
+- **Display placement/output config** is configured through Ubuntu Frame's own configuration
+  (see the [Ubuntu Frame docs](https://snapcraft.io/ubuntu-frame)), not through invented
+  `daemon.*` keys.
+
+## 6. Camera (USB UVC + Raspberry Pi CSI)
+
+`run-booth` auto-detects the source at launch: a genuine USB UVC node becomes `v4l2src`,
+otherwise a Pi CSI camera is driven through `libcamerasrc`. It exports `BOOTH_CAMERA_KIND`
+and `DEFAULT_CAMERA_DEVICE`, which the app's GStreamer pipeline reads.
 
 ```bash
-# Access CUPS web interface
-# Open browser and navigate to: http://<device-ip>:631
-
-# Enable remote access (if needed)
-sudo snap set cups interface.enable=true
-sudo snap connect cups:network-control
-```
-
-## Camera Configuration
-
-### Camera Detection and Setup
-
-```bash
-# Check available cameras
+# USB cameras:
 v4l2-ctl --list-devices
 
-# Test camera
-gst-launch-1.0 v4l2src device=/dev/video0 ! videoconvert ! autovideosink
+# Pi CSI (after the gadget config.txt enables it):
+ls /dev/media*
+cat /sys/class/video4linux/*/name | grep -i cfe    # expect rp1-cfe
 
-# Check camera capabilities
-v4l2-ctl --device=/dev/video0 --list-formats-ext
+# What the booth picked (from its own logs):
+snap logs ubu4cut | grep -i 'Camera: kind='
 
-# Set camera resolution
-v4l2-ctl --device=/dev/video0 --set-fmt-video=width=1920,height=1080,pixelformat=YUYV
+# Manual pipeline smoke tests (gstreamer1.0-tools is staged in the snap):
+gst-launch-1.0 v4l2src device=/dev/video0 ! videoconvert ! fakesink
+gst-launch-1.0 libcamerasrc ! video/x-raw,format=NV12,width=1640,height=1232 ! videoconvert ! fakesink
 ```
 
-### Camera Permissions
+Force a source when detection guesses wrong: `BOOTH_CAMERA_KIND=libcamera`, or
+`BOOTH_CAMERA_KIND=v4l2` together with `DEFAULT_CAMERA_DEVICE=/dev/videoN`.
+
+If the CSI camera never appears, the gadget `config.txt` is missing `camera_auto_detect` or
+full KMS — go back to [`gadget-camera-kms.md`](gadget-camera-kms.md).
+
+## 7. Printing (CUPS + `lp`)
+
+The app composites the four-cut PNG in memory and prints it with the CUPS `lp` client — there
+is no bundled print server. A **Printer Application** (driverless IPP) provides the PNG→raster
+driver for the dye-sub.
 
 ```bash
-# Check camera permissions
-snap connections linux-photo-booth
+lpstat -p                                    # is the printer discovered?
+sudo lpadmin -d <printer>                    # set the default (or use http://localhost:631)
+snap set ubu4cut print.media=4x6 print.borderless=true
 
-# Connect camera interface
-sudo snap connect linux-photo-booth:camera
-
-# Test camera access
-sudo snap run linux-photo-booth
+# Diagnose a failed job:
+snap logs ubu4cut
+lpstat -W all
 ```
 
-## Security Configuration
+`print.media` / `print.borderless` are read by the `configure` hook into
+`$SNAP_DATA/print-config.env`, exported by `run-booth`, and passed to `lp` by the print page.
 
-### Firewall Setup
+## 8. Interfaces & confinement
 
 ```bash
-# Enable UFW firewall
-sudo ufw --force enable
-
-# Allow SSH access
-sudo ufw allow ssh
-
-# Allow CUPS web interface
-sudo ufw allow 631
-
-# Check firewall status
-sudo ufw status verbose
+snap connections ubu4cut        # expect camera, cups, wayland (no cups-control, no raw-usb)
 ```
 
-### Snap Security
+The kiosk runs in **devmode** today because the Pi 5 CSI path needs libcamera to open
+`/dev/media*`, which snapd's `camera` interface does not cover. The clean fix — a gadget
+`camera-csi` `custom-device` slot so the booth can run in strict confinement — is documented,
+with its store-review implications, in [`gadget-camera-kms.md`](gadget-camera-kms.md). Keep
+`grade: devel` until the no-hardware gate and the RPi 5 acceptance checklist both pass, then
+rebuild at `grade: stable`.
+
+## 9. Logs
 
 ```bash
-# Check snap confinement
-snap list --all
-
-# Review snap connections
-snap connections
-
-# Check snap permissions
-snap connections linux-photo-booth
-```
-
-### System Monitoring
-
-```bash
-# Install monitoring tools
-sudo snap install htop
-
-# Monitor system resources
-htop
-
-# Check disk usage
-df -h
-
-# Monitor network
-iftop
-```
-
-## Performance Optimization
-
-### Memory Optimization
-
-```bash
-# Check memory usage
-free -h
-
-# Monitor memory usage over time
-watch -n 1 free -h
-
-# Check swap usage
-swapon --show
-```
-
-### Storage Optimization
-
-```bash
-# Check disk usage
-df -h
-
-# Clean old snap versions
-sudo snap set system refresh.retain=2
-
-# Clean temporary files
-sudo journalctl --vacuum-time=7d
-```
-
-### Network Optimization
-
-```bash
-# Check network performance
-iperf3 -c 8.8.8.8
-
-# Monitor network usage
-iftop
-
-# Configure network buffer sizes (if needed)
-sudo sysctl -w net.core.rmem_max=26214400
-sudo sysctl -w net.core.wmem_max=26214400
-```
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-#### Display Issues
-```bash
-# Check Frame service status
-sudo snap services ubuntu-frame
-
-# Restart Frame service
-sudo snap restart ubuntu-frame
-
-# Check display environment
-env | grep -E "(DISPLAY|WAYLAND|XDG)"
-
-# Reset Frame configuration
-sudo snap set ubuntu-frame daemon.enable=false
-sudo snap set ubuntu-frame daemon.enable=true
-```
-
-#### Camera Issues
-```bash
-# Check camera device
-ls -la /dev/video*
-
-# Test camera with GStreamer
-gst-launch-1.0 v4l2src device=/dev/video0 ! videoconvert ! autovideosink
-
-# Check camera permissions
-sudo usermod -aG video ubuntu
-
-# Reconnect camera interface
-sudo snap disconnect linux-photo-booth:camera
-sudo snap connect linux-photo-booth:camera
-```
-
-#### Printer Issues
-```bash
-# Check CUPS service
-sudo snap services cups
-
-# Restart CUPS service
-sudo snap restart cups
-
-# Check printer connections
-snap connections cups
-
-# Test printer communication
-lpstat -p
-echo "Test" | lp
-```
-
-#### Network Issues
-```bash
-# Check network configuration
-ip addr show
-ip route show
-
-# Test network connectivity
-ping -c 3 8.8.8.8
-nslookup google.com
-
-# Check DNS resolution
-systemd-resolve --status
-```
-
-### Debug Commands
-
-```bash
-# System information
-uname -a
-cat /etc/os-release
-snap version
-
-# Hardware information
-lscpu
-free -h
-df -h
-lsusb
-lspci
-
-# Service status
-systemctl status
-snap services
-
-# Log analysis
-journalctl -f
-sudo snap logs ubuntu-frame
-sudo snap logs linux-photo-booth
-```
-
-## Backup and Recovery
-
-### System Backup
-
-```bash
-# Create system backup
-sudo snap save photo-booth-system-backup
-
-# List available backups
-sudo snap saved
-
-# Create configuration backup
-sudo tar -czf /home/ubuntu/photo-booth-config-backup.tar.gz \
-    /etc/systemd/system/photo-booth-server.service \
-    /usr/local/bin/photo-booth-*.sh \
-    /etc/cron.d/photo-booth-monitor \
-    /etc/logrotate.d/photo-booth
-```
-
-### Recovery Procedures
-
-```bash
-# Restore from snap backup
-sudo snap restore <backup-id>
-
-# Restore configuration files
-sudo tar -xzf /home/ubuntu/photo-booth-config-backup.tar.gz -C /
-
-# Restart services after recovery
-sudo snap restart ubuntu-frame
-sudo snap restart linux-photo-booth
-```
-
-## Maintenance
-
-### Regular Maintenance Tasks
-
-```bash
-# Daily tasks
-sudo snap refresh --list
-sudo journalctl --vacuum-time=7d
-
-# Weekly tasks
-sudo snap save weekly-backup
-sudo apt update && sudo apt upgrade
-
-# Monthly tasks
-sudo snap set system refresh.retain=2
-sudo logrotate -f /etc/logrotate.d/photo-booth
-```
-
-### Monitoring Scripts
-
-The setup script creates monitoring scripts that:
-- Check application status every 5 minutes
-- Monitor disk usage and clean old files
-- Restart services if they fail
-- Create automatic backups
-
-### Log Management
-
-```bash
-# View application logs
-sudo snap logs linux-photo-booth -f
-
-# View system logs
+snap logs ubu4cut -f                         # both app entries
+snap logs ubu4cut.ubu4cut-kiosk -n 100       # just the kiosk daemon
+snap logs ubuntu-frame
 journalctl -u snap.ubuntu-frame.ubuntu-frame -f
-
-# Configure log rotation
-sudo nano /etc/logrotate.d/photo-booth
 ```
 
-## Support and Resources
+Ubuntu Core manages log storage itself — there are no cron monitors, `logrotate` drop-ins, or
+custom backup services to install (and `setup-ubuntu-core.sh` intentionally installs none).
 
-### Official Documentation
-- [Ubuntu Core Documentation](https://ubuntu.com/core/docs)
-- [Ubuntu Frame Documentation](https://snapcraft.io/ubuntu-frame)
-- [Snapcraft Documentation](https://snapcraft.io/docs)
+## 10. Updates & rollback
 
-### Community Resources
-- [Ubuntu Forums](https://ubuntuforums.org/)
-- [Snapcraft Community](https://forum.snapcraft.io/)
-- [Raspberry Pi Forums](https://www.raspberrypi.org/forums/)
+```bash
+sudo snap refresh --list                     # what's pending
+sudo snap refresh ubu4cut                    # update just the booth
+snap set system refresh.retain=2             # keep 2 revisions for rollback
+sudo snap revert ubu4cut                     # roll back to the previous revision
+```
 
-### Troubleshooting Resources
-- [Ubuntu Core Troubleshooting](https://ubuntu.com/core/docs/troubleshooting)
-- [Snap Troubleshooting](https://snapcraft.io/docs/troubleshooting)
-- [GStreamer Documentation](https://gstreamer.freedesktop.org/documentation/)
+Ubuntu Core refreshes snaps automatically in the background; `refresh.retain` keeps prior
+revisions so a bad refresh can be reverted.
 
----
+## 11. Troubleshooting quick reference
 
-This guide covers advanced configuration options for Ubuntu Core. For basic installation, refer to the main README.md file. 
+| Symptom | First checks |
+|---|---|
+| Nothing on screen under Frame | `ls /dev/dri/card0` (full KMS), `snap services ubuntu-frame`, `snap logs ubu4cut.ubu4cut-kiosk` |
+| Preview shows test pattern / black | `snap logs ubu4cut \| grep Camera:`, `ls /dev/media*`, reconnect `ubu4cut:camera` |
+| Kiosk not autostarting | `snap services ubu4cut` (is `ubu4cut-kiosk` enabled/active?), re-run `snap start --enable ubu4cut.ubu4cut-kiosk` |
+| Print does nothing | `lpstat -p`, default set via `lpadmin -d`, Printer Application installed |
+| Interface missing | `snap connections ubu4cut` → connect `camera` / `cups` / `wayland` |
+
+## Support & references
+
+- [Ubuntu Core documentation](https://ubuntu.com/core/docs)
+- [Ubuntu Frame](https://snapcraft.io/ubuntu-frame)
+- [Snapcraft](https://snapcraft.io/docs)
+- [libcamera](https://libcamera.org/) · [GStreamer](https://gstreamer.freedesktop.org/documentation/)

--- a/ubuntu-core/make-auto-import.sh
+++ b/ubuntu-core/make-auto-import.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Generate ./auto-import.assert (system-user + account + account-key chain).
+#
+# Put the resulting auto-import.assert on the ROOT of a FAT32/ext4 USB stick,
+# boot the Pi (Core 26 custom image) with it inserted, and snapd auto-creates a
+# LOCAL-LOGIN user at first boot — NO console-conf, NO first-boot network needed.
+# You then log in on the Pi's touch monitor + keyboard (KMS works on Core 26) and
+# fix the onboard Wi-Fi from a real shell. The user also carries the SSH key, so
+# once Wi-Fi/Ethernet is up you can `ssh ubu4cut@<ip>` too.
+#
+# Prereq (one-time): Ubuntu One dev account + a registered signing key:
+#   snap login ; snapcraft login
+#   snapcraft create-key ubu4cut ; snapcraft register-key ubu4cut
+#   snapcraft whoami       # -> developer-id  == BRAND_ID (must match the model)
+#
+# Usage (run where snap+snapcraft are logged in — e.g. the build container):
+#   BRAND_ID=<developer-id> EMAIL=<ubuntu-one-email> KEY_NAME=ubu4cut \
+#     ubuntu-core/make-auto-import.sh ubuntu-core/system-user.json
+set -euo pipefail
+
+SRC="${1:-ubuntu-core/system-user.json}"
+: "${BRAND_ID:?set BRAND_ID (snapcraft whoami -> developer-id)}"
+: "${EMAIL:?set EMAIL (your Ubuntu One email)}"
+: "${KEY_NAME:=ubu4cut}"
+: "${USERNAME:=ubu4cut}"
+[ -f "$SRC" ] || { echo "ERROR: $SRC not found" >&2; exit 1; }
+
+printf 'Set LOCAL login password for user "%s": ' "$USERNAME" >&2
+read -rs PW; echo >&2
+[ -n "$PW" ] || { echo "ERROR: empty password" >&2; exit 1; }
+HASH="$(openssl passwd -6 "$PW")"     # sha512crypt ($6$...)
+SINCE="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+UNTIL="$(date -u -d '+3 years' +%Y-%m-%dT%H:%M:%S+00:00 2>/dev/null || date -u -v+3y +%Y-%m-%dT%H:%M:%S+00:00)"
+
+BRAND_ID="$BRAND_ID" EMAIL="$EMAIL" USERNAME="$USERNAME" HASH="$HASH" SINCE="$SINCE" UNTIL="$UNTIL" \
+python3 - "$SRC" <<'PY' | snap sign -k "$KEY_NAME" --chain > auto-import.assert
+import json, os, sys
+d = json.load(open(sys.argv[1]))
+d["authority-id"] = d["brand-id"] = os.environ["BRAND_ID"]
+d["email"] = os.environ["EMAIL"]
+d["username"] = os.environ["USERNAME"]
+d["password"] = os.environ["HASH"]
+d["since"] = os.environ["SINCE"]
+d["until"] = os.environ["UNTIL"]
+json.dump(d, sys.stdout)
+PY
+
+echo "wrote ./auto-import.assert" >&2
+echo "-> copy to the ROOT of a FAT32/ext4 USB stick, boot the Pi with it inserted" >&2

--- a/ubuntu-core/model/ubu4cut-core-24-pi-arm64.model.json
+++ b/ubuntu-core/model/ubu4cut-core-24-pi-arm64.model.json
@@ -1,0 +1,39 @@
+{
+  "type": "model",
+  "series": "16",
+  "authority-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "brand-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "model": "ubu4cut-core-24-pi-arm64",
+  "architecture": "arm64",
+  "base": "core24",
+  "grade": "dangerous",
+  "snaps": [
+    {
+      "name": "pi",
+      "type": "gadget",
+      "default-channel": "24/stable"
+    },
+    {
+      "name": "pi-kernel",
+      "type": "kernel",
+      "default-channel": "24/stable"
+    },
+    {
+      "name": "core24",
+      "type": "base",
+      "default-channel": "latest/stable"
+    },
+    {
+      "name": "snapd",
+      "type": "snapd",
+      "default-channel": "latest/stable"
+    },
+    {
+      "name": "console-conf",
+      "type": "app",
+      "default-channel": "24/stable",
+      "presence": "optional"
+    }
+  ],
+  "timestamp": "REPLACE_WITH_ISO8601_UTC"
+}

--- a/ubuntu-core/model/ubu4cut-core-26-pi-arm64.model.json
+++ b/ubuntu-core/model/ubu4cut-core-26-pi-arm64.model.json
@@ -1,0 +1,18 @@
+{
+  "type": "model",
+  "series": "16",
+  "authority-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "brand-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "model": "ubu4cut-core-26-pi-arm64",
+  "architecture": "arm64",
+  "base": "core26",
+  "grade": "dangerous",
+  "system-user-authority": "*",
+  "snaps": [
+    { "name": "pi", "type": "gadget", "default-channel": "26/stable" },
+    { "name": "pi-kernel", "type": "kernel", "default-channel": "26/stable" },
+    { "name": "core26", "type": "base", "default-channel": "latest/stable" },
+    { "name": "snapd", "type": "snapd", "default-channel": "latest/stable" }
+  ],
+  "timestamp": "REPLACE_WITH_ISO8601_UTC"
+}

--- a/ubuntu-core/rpi5-acceptance-checklist.md
+++ b/ubuntu-core/rpi5-acceptance-checklist.md
@@ -1,0 +1,39 @@
+# RPi5 수용 체크리스트 (사용자 실기 검증)
+
+무하드웨어 게이트(build/lint/review-tools/frame-it) 통과 후, 실제 RPi5 + Ubuntu Core에서
+아래를 순서대로 확인합니다. 각 항목 통과 시 [ ] → [x].
+
+## 0. 사전 (gadget/카메라·KMS)
+- [ ] `ubuntu-core/gadget-camera-kms.md`대로 커스텀 이미지(카메라+풀 KMS)를 **예비 SD**에 굽고 부팅.
+- [ ] `ls /dev/media*` 및 `/sys/class/video4linux/*/name`에 `rp1-cfe` 등장(센서 인식).
+- [ ] `ls /dev/dri/`에 `card0`(풀 KMS) 존재.
+
+## 1. 설치 & 배선
+- [ ] `sudo snap install --dangerous ubu4cut_*.snap` (또는 스토어 설치).
+- [ ] `sudo ubuntu-core/setup-ubuntu-core.sh` 실행(ubuntu-frame/cups/printer-app 설치·연결).
+- [ ] `snap connections ubu4cut` → `camera`, `cups`, `wayland` 연결됨(`cups-control` 없음).
+
+## 2. 키오스크 자동시작
+- [ ] `snap services ubu4cut` → `ubu4cut-kiosk` **enabled/active**.
+- [ ] 재부팅 후 Ubuntu Frame 안에서 부스 UI가 **자동 전체화면**으로 뜸.
+- [ ] `snap logs ubu4cut.ubu4cut-kiosk -n 100`에 wayland/렌더 오류 없음.
+
+## 3. 카메라 (CSI)
+- [ ] 부스 프리뷰에 **실제 카메라 영상**이 표시(테스트 패턴 아님).
+- [ ] `BOOTH_CAMERA_KIND=libcamera` 경로로 CSI가 잡힘(로그 `Camera: kind=libcamera`).
+- [ ] (참고) 네컷 캡처 결과 이미지에 실제 영상이 담기는지 — **캡처 로직은 별도 트랙(IR2)**.
+      현재 외부 Texture 캡처 한계로 빈 프레임일 수 있음(후속 이슈에서 appsink 직접 취득으로 수정).
+
+## 4. 데스크톱 앱 (선택, 동일 snap)
+- [ ] Ubuntu Desktop에서 앱 메뉴로 `ubu4cut` 수동 실행 → 정상 창.
+
+## 5. 프린트 (USB 염료승화)
+- [ ] 프린터 연결 후 Printer Application이 인식(`lpstat -p`에 등장).
+- [ ] `lpadmin -d <printer>`로 기본 프린터 설정(또는 631 웹 UI).
+- [ ] `snap set ubu4cut print.media=4x6 print.borderless=true` 반영.
+- [ ] 부스에서 인쇄 실행 → 실제 4x6 출력물이 나옴(여백/색 확인).
+- [ ] 실패 시 `snap logs`/`lpstat -W all`로 PNG→raster 필터/미디어 옵션 점검.
+
+## 6. 정리
+- [ ] 모든 항목 통과 후 `grade: stable`로 재빌드/재배포(선택).
+- [ ] 예비 SD 검증 완료 후에만 운영 기기 재이미징(원본 롤백 이미지 보관).

--- a/ubuntu-core/setup-ubuntu-core.sh
+++ b/ubuntu-core/setup-ubuntu-core.sh
@@ -1,144 +1,70 @@
 #!/bin/bash
+# Ubuntu Core kiosk wiring for Ubu4Cut — essential wiring only.
+#
+# Scope: install and connect the runtime substrate (Ubuntu Frame, CUPS, a dye-sub
+# Printer Application), install the booth snap, and enable the kiosk daemon.
+#
+# NOT in scope (removed on purpose): cron monitors, `snap save` backups, ufw,
+# logrotate, and /boot/firmware/config.txt edits. Enabling the CSI camera + full
+# KMS requires a gadget/config.txt change — see ubuntu-core/gadget-camera-kms.md
+# (a stock signed model needs a custom gadget + custom model + re-image).
+set -euo pipefail
 
-# Ubuntu Core + Ubuntu Frame Photo Booth Setup Script
-# This script automates the setup of a photo booth kiosk using Ubuntu Core
+BOOTH_SNAP="ubu4cut"
+KIOSK_APP="${BOOTH_SNAP}.ubu4cut-kiosk"
+PRINTER_APP_SNAP="${PRINTER_APP_SNAP:-gutenprint-printer-app}"
 
-set -e
+echo "== Ubu4Cut :: Ubuntu Core kiosk setup =="
 
-echo "Setting up Ubuntu Core Photo Booth Kiosk..."
-
-# Check if running on Ubuntu Core
-if ! snap list | grep -q "ubuntu-core"; then
-    echo "ERROR: This script is designed for Ubuntu Core"
-    echo "Please install Ubuntu Core first: https://ubuntu.com/core/docs/getting-started"
-    exit 1
+if ! snap list 2>/dev/null | grep -q '^core24'; then
+    echo "WARNING: this does not look like Ubuntu Core; continuing anyway." >&2
 fi
 
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then
-    echo "ERROR: This script must be run as root (use sudo)"
-    exit 1
-fi
-
-echo "Installing Ubuntu Frame..."
+echo "-- Installing Ubuntu Frame (Wayland compositor) --"
 snap install ubuntu-frame
+snap set ubuntu-frame daemon=true            # valid Frame key (NOT daemon.command)
 
-echo "Configuring Ubuntu Frame..."
-snap set ubuntu-frame daemon.enable=true
-snap set ubuntu-frame daemon.restart-condition=always
-snap set ubuntu-frame daemon.restart-delay=10s
-
-echo "Installing CUPS for printing..."
+echo "-- Installing CUPS + Printer Application (dye-sub) --"
 snap install cups
-snap set cups interface.enable=true
+snap install "$PRINTER_APP_SNAP"             # exposes the USB dye-sub as driverless IPP
 
-echo "Connecting CUPS interfaces..."
-snap connect cups:usb-control
-snap connect cups:network-control
-
-echo "Installing display utilities..."
-snap install xinput-calibrator
-
-echo "Creating configuration directory..."
-mkdir -p /home/ubuntu/.photo-booth
-chown ubuntu:ubuntu /home/ubuntu/.photo-booth
-
-echo "Creating monitoring script..."
-cat > /usr/local/bin/photo-booth-monitor.sh << 'EOF'
-#!/bin/bash
-
-LOG_FILE="/home/ubuntu/.photo-booth/kiosk.log"
-APP_PID=$(pgrep -f "linux-photo-booth")
-
-if [ -z "$APP_PID" ]; then
-    echo "$(date): Photo booth app not running, restarting..." >> "$LOG_FILE"
-    snap restart ubuntu-frame
+echo "-- Installing the photo booth snap --"
+# Store: `snap install ubu4cut`.
+# Local sideload during development:
+#   sudo snap install --dangerous ${BOOTH_SNAP}_*.snap
+if ! snap list "$BOOTH_SNAP" >/dev/null 2>&1; then
+    if ls "${BOOTH_SNAP}"_*.snap >/dev/null 2>&1; then
+        snap install --dangerous "$(ls -1 ${BOOTH_SNAP}_*.snap | head -1)"
+    else
+        echo "NOTE: ${BOOTH_SNAP} not installed and no local .snap found; install it, then re-run." >&2
+    fi
 fi
 
-# Check disk space
-DISK_USAGE=$(df / | awk 'NR==2 {print $5}' | sed 's/%//')
-if [ "$DISK_USAGE" -gt 90 ]; then
-    echo "$(date): Disk usage high: ${DISK_USAGE}%" >> "$LOG_FILE"
-    # Clean up old photos
-    find /home/ubuntu/Pictures -name "*.png" -mtime +7 -delete 2>/dev/null || true
-fi
+echo "-- Connecting interfaces (sideload does not auto-connect) --"
+# `cups` auto-connects from the store; connect explicitly for --dangerous installs.
+for slotpair in \
+    "${BOOTH_SNAP}:camera" \
+    "${BOOTH_SNAP}:cups cups:cups" \
+    "${KIOSK_APP%.*}:wayland"; do
+    snap connect $slotpair 2>/dev/null || echo "  (skip/verify: snap connect $slotpair)"
+done
+
+echo "-- Enabling the kiosk daemon (install-mode:disable requires explicit enable) --"
+snap start --enable "$KIOSK_APP" || echo "  (verify kiosk app name: $KIOSK_APP)"
+
+cat <<EOF
+
+== Setup complete ==
+Next / verify:
+  snap connections ${BOOTH_SNAP}          # confirm camera/cups/wayland are connected
+  snap services ${BOOTH_SNAP}             # kiosk daemon should be enabled/active
+  snap logs ${KIOSK_APP} -n 50            # boot/render logs
+  # Set the default printer once the dye-sub is detected by the Printer Application:
+  #   lpstat -p            (via the cups snap)
+  #   lpadmin -d <printer> # or the cups web UI at http://localhost:631
+  # Configure photo media (defaults 4x6 / borderless):
+  #   snap set ${BOOTH_SNAP} print.media=4x6 print.borderless=true
+
+CSI camera + full KMS are NOT enabled by this script (gadget-owned config.txt).
+See ubuntu-core/gadget-camera-kms.md.
 EOF
-
-chmod +x /usr/local/bin/photo-booth-monitor.sh
-
-echo "Setting up monitoring cron job..."
-cat > /etc/cron.d/photo-booth-monitor << 'EOF'
-*/5 * * * * root /usr/local/bin/photo-booth-monitor.sh
-EOF
-
-echo "Creating backup script..."
-cat > /usr/local/bin/photo-booth-backup.sh << 'EOF'
-#!/bin/bash
-
-BACKUP_DIR="/home/ubuntu/backups"
-DATE=$(date +%Y%m%d_%H%M%S)
-
-mkdir -p "$BACKUP_DIR"
-snap save photo-booth-config-$DATE
-
-# Keep only last 7 backups
-snap saved | grep photo-booth-config | tail -n +8 | awk '{print $1}' | xargs -r snap forget
-EOF
-
-chmod +x /usr/local/bin/photo-booth-backup.sh
-
-echo "Configuring Raspberry Pi 5 hardware optimizations..."
-if [ -f /boot/firmware/config.txt ]; then
-    # Avoid duplicate entries
-    grep -q "disable_overscan" /boot/firmware/config.txt || echo "disable_overscan=1" >> /boot/firmware/config.txt
-    grep -q "dtoverlay=vc4-kms-v3d" /boot/firmware/config.txt || echo "dtoverlay=vc4-kms-v3d" >> /boot/firmware/config.txt
-    grep -q "max_framebuffers" /boot/firmware/config.txt || echo "max_framebuffers=2" >> /boot/firmware/config.txt
-    grep -q "camera_auto_detect" /boot/firmware/config.txt || echo "camera_auto_detect=1" >> /boot/firmware/config.txt
-    echo "Raspberry Pi 5 hardware optimization applied"
-else
-    echo "WARNING: /boot/firmware/config.txt not found - skipping hardware optimization"
-fi
-
-echo "Setting up firewall..."
-ufw --force enable
-ufw allow ssh
-ufw allow 631  # CUPS web interface
-
-echo "Setting up log rotation..."
-cat > /etc/logrotate.d/photo-booth << 'EOF'
-/home/ubuntu/.photo-booth/*.log {
-    daily
-    missingok
-    rotate 7
-    compress
-    notifempty
-    create 644 ubuntu ubuntu
-}
-EOF
-
-echo "Ubuntu Core Photo Booth Kiosk setup complete!"
-echo ""
-echo "Next steps:"
-echo "1. Build and install the snap package:"
-echo "   ./build-snap.sh"
-echo "   scp linux-photo-booth_*.snap ubuntu@<raspberry-pi-ip>:~/"
-echo "   sudo snap install --dangerous linux-photo-booth_*.snap"
-echo ""
-echo "2. Connect snap interfaces (desktop, wayland, x11, opengl are auto-connected via gnome extension):"
-echo "   sudo snap connect linux-photo-booth:camera"
-echo "   sudo snap connect linux-photo-booth:cups-control"
-echo "   sudo snap connect linux-photo-booth:raw-usb"
-echo ""
-echo "3. Configure Ubuntu Frame:"
-echo "   sudo snap set ubuntu-frame daemon.command='linux-photo-booth'"
-echo "   sudo snap restart ubuntu-frame"
-echo ""
-echo "4. Test the setup:"
-echo "   sudo snap services ubuntu-frame"
-echo "   sudo snap logs ubuntu-frame"
-echo ""
-echo "Troubleshooting:"
-echo "- Check logs: sudo snap logs ubuntu-frame"
-echo "- Check services: sudo snap services"
-echo "- Restart Frame: sudo snap restart ubuntu-frame"
-echo "- Test camera: v4l2-ctl --list-devices" 

--- a/ubuntu-core/sign-model.sh
+++ b/ubuntu-core/sign-model.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Sign the Ubu4Cut Ubuntu Core model assertion for a dangerous (dev) build.
+#
+# WHY dangerous grade: the image ships a locally-built (unasserted) custom `pi`
+# gadget. `grade: dangerous` is what lets Ubuntu Core boot unasserted snaps.
+#
+# One-time key setup (needs a free Ubuntu One / snapcraft developer account —
+# you already have one if the Pi went through console-conf):
+#   snapcraft login
+#   snapcraft create-key ubu4cut      # local key in snapd's keyring
+#   snapcraft register-key ubu4cut    # registers the PUBLIC part to your account
+#   snapcraft whoami                     # -> "developer-id: <ID>"  == your BRAND_ID
+#
+# Usage:
+#   BRAND_ID=<developer-id> KEY_NAME=ubu4cut \
+#     ubuntu-core/sign-model.sh ubuntu-core/model/ubu4cut-core-24-pi-arm64.model.json > ubu4cut.model
+#
+# The signed ./ubu4cut.model is then consumed by ubuntu-core/build-image.sh.
+set -euo pipefail
+
+SRC="${1:?usage: sign-model.sh <model.json> > out.model}"
+: "${BRAND_ID:?set BRAND_ID to your snapcraft developer-id (see: snapcraft whoami)}"
+: "${KEY_NAME:=ubu4cut}"
+
+[ -f "$SRC" ] || { echo "ERROR: model json not found: $SRC" >&2; exit 1; }
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Fill placeholders, then sign. `snap sign` reads the JSON model on stdin and
+# emits the signed assertion on stdout.
+sed -e "s/REPLACE_WITH_YOUR_BRAND_ID/${BRAND_ID}/g" \
+    -e "s/REPLACE_WITH_ISO8601_UTC/${TS}/g" \
+    "$SRC" | snap sign -k "$KEY_NAME"

--- a/ubuntu-core/system-user.json
+++ b/ubuntu-core/system-user.json
@@ -1,0 +1,14 @@
+{
+  "type": "system-user",
+  "authority-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "brand-id": "REPLACE_WITH_YOUR_BRAND_ID",
+  "series": ["16"],
+  "email": "REPLACE_WITH_YOUR_UBUNTU_ONE_EMAIL",
+  "models": ["ubu4cut-core-26-pi-arm64"],
+  "name": "Ubu4Cut Admin",
+  "username": "ubu4cut",
+  "password": "REPLACE_WITH_SHA512CRYPT_HASH",
+  "ssh-keys": ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOgNWzzaXjG33+F88idX2DoGKJv77lkzvc1h2jVX1GMc"],
+  "since": "REPLACE_WITH_SINCE",
+  "until": "REPLACE_WITH_UNTIL"
+}


### PR DESCRIPTION
This branch is a single commit (`e7b224a`) that bundles three changes made together. The **360° rotation fix** (the part just requested) is detailed first; the rename + docs it was committed alongside follow.

## Fix: booth UI now rotates a full 360° (90° steps)

**Problem**
- `OrientationController.toggle()` only flipped landscape (0°) ↔ one portrait (90°/270°) — a 2-state toggle that could never reach 180° or complete a full turn.
- `main.dart` swapped `width`↔`height` for *every* non-zero rotation, so even if 180° were reached the layout broke (a 180° turn keeps the same dimensions).

**Fix**
- `OrientationController`: `toggle()` → `rotate()`, cycling `(value + 1) % 4` → `0 → 90 → 180 → 270 → 0`. Added `degrees` and `isPortrait = quarterTurns.isOdd`.
- `main.dart`: swap dimensions only for odd quarter-turns (90°/270°); keep them for 0°/180°.
- `homePage.dart`: the rotate button calls `rotate()` and shows the current angle (`화면 회전 <angle>° (탭하면 90°)`).

Files: `lib/controllers/orientationController.dart`, `lib/main.dart`, `lib/pages/homePage.dart`.

## Rename: Linux Photo Booth → Ubu4Cut

Full rebrand across every shipped surface: display name, snap (`ubu4cut` + `ubu4cut-kiosk`), Dart package/binary, GTK app ID, `.desktop` (renamed), Ubuntu Core model assertions (`ubu4cut-core-24|26-pi-arm64`), signing key / local user, and all identifiers in scripts and docs. Generic terms (`run-booth`, `BOOTH_*` env, vendored `flutter_gstreamer_player`) and generated `macos/` scaffolding were left as-is.

## Docs refreshed to match the current spec

- `README.md` and `ubuntu-core/install-ubuntu-core.md` rewritten to reflect reality: dual-app snap, `devmode` / `grade devel`, `gnome` extension + real interfaces (`cups`, not `cups-control`; no `raw-usb`), in-app CUPS `lp` printing (the old Flask server is gone), USB v4l2 + Raspberry Pi CSI/libcamera camera, and the Core 24/26 KMS-vs-Wi-Fi trade-off.
- Removed stale/fictional content (X11 calibration, `ufw`, cron/logrotate monitors, a `photo-booth-server.service`, invalid `ubuntu-frame daemon.command`).

## Testing

- `flutter pub get` resolves the renamed `ubu4cut` package; `dart format` is clean.
- `flutter analyze` / `flutter test` could not run in the authoring environment (broken local Flutter SDK cache — missing `analysis_server` snapshot and `flutter_tester` engine). Please verify on Linux / RPi 5:
  - Tap the home-screen rotate button 4× → `0° → 90° → 180° → 270° → 0°`, confirming **180° no longer breaks the layout**.
  - `BOOTH_PORTRAIT=1` / `BOOTH_PORTRAIT_TURNS=1|3` set the initial orientation.

## Note

The rotation fix and the rename were committed together in one commit, so this single PR covers both. If you'd prefer the rotation fix as a standalone PR, it can be split out onto its own branch off `main` (needs either splitting the pushed commit or a fresh branch).
