### PR TITLE
feat: configurable initial screen rotation (rotate.turns) for flipped monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,15 @@ Runtime-tunable at startup, no rebuild required:
 |---|---|---|
 | `BOOTH_PORTRAIT` | `0` | `1` starts the UI in portrait. |
 | `BOOTH_PORTRAIT_TURNS` | `3` | Clockwise quarter-turns for portrait (`1` or `3`). |
+| `BOOTH_ROTATE_TURNS` | unset | Initial rotation, 0..3 quarter-turns (`2` = 180° flip). Set via `snap set ubu4cut rotate.turns=N`. |
 | `BOOTH_TAP_GUARD_MS` | `300` | Post-transition input guard; `0` disables it. |
 | `BOOTH_PREVIEW_WIDTH` / `BOOTH_PREVIEW_HEIGHT` | `525` / `700` | Preview & capture box size. |
 | `BOOTH_CAMERA_KIND` / `DEFAULT_CAMERA_DEVICE` | auto | Override camera detection. |
 | `BOOTH_PRINT_MEDIA` / `BOOTH_PRINT_BORDERLESS` | `4x6` / `true` | Set via `snap set … print.*`. |
 | `BOOTH_AUTOSTART_CAMERA` | unset | Test hook: auto-open the camera page. Off in production. |
 
-Only `print.media` / `print.borderless` are exposed as snap config; the rest are process
-environment variables (set them in `run-booth` or a systemd drop-in for the kiosk daemon).
+`print.media` / `print.borderless` / `rotate.turns` are exposed as snap config
+(`snap set ubu4cut …`); the rest are process environment variables read at startup.
 
 ## Development
 

--- a/lib/controllers/orientationController.dart
+++ b/lib/controllers/orientationController.dart
@@ -7,8 +7,9 @@ import 'package:get/get.dart';
 /// `main.dart` and cycles the full 360° in 90° steps:
 /// 0 = landscape, 1 = 90°, 2 = 180° (landscape flipped), 3 = 270°.
 ///
-/// Initial state comes from env (BOOTH_PORTRAIT / BOOTH_PORTRAIT_TURNS) and it
-/// is rotated at runtime from the home screen.
+/// Initial state comes from env — `BOOTH_ROTATE_TURNS` (0..3 quarter-turns; use
+/// 2 for a 180°-flipped monitor) or the legacy BOOTH_PORTRAIT /
+/// BOOTH_PORTRAIT_TURNS — and it is rotated at runtime from the home screen.
 class OrientationController extends GetxController {
   final RxInt quarterTurns = _initialTurns.obs;
 
@@ -39,6 +40,12 @@ class OrientationController extends GetxController {
     return (v == 1 || v == 3) ? v : 3;
   }
 
-  static int get _initialTurns =>
-      Platform.environment['BOOTH_PORTRAIT'] == '1' ? _portraitTurns : 0;
+  /// Initial rotation at startup. `BOOTH_ROTATE_TURNS` (0..3) sets it directly —
+  /// use 2 for a 180°-flipped monitor; otherwise falls back to the legacy
+  /// BOOTH_PORTRAIT (+ BOOTH_PORTRAIT_TURNS) toggle.
+  static int get _initialTurns {
+    final t = int.tryParse(Platform.environment['BOOTH_ROTATE_TURNS'] ?? '');
+    if (t != null && t >= 0 && t <= 3) return t;
+    return Platform.environment['BOOTH_PORTRAIT'] == '1' ? _portraitTurns : 0;
+  }
 }

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -35,5 +35,9 @@ umask 022
 {
     echo "BOOTH_PRINT_MEDIA=$media"
     echo "BOOTH_PRINT_BORDERLESS=$borderless"
-    [ -n "$turns" ] && echo "BOOTH_ROTATE_TURNS=$turns"
+    if [ -n "$turns" ]; then
+        echo "BOOTH_ROTATE_TURNS=$turns"
+    fi
 } > "$SNAP_DATA/print-config.env"
+
+exit 0

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,12 +1,13 @@
 #!/bin/bash
-# configure hook: exposes print media as snap configuration.
+# configure hook: exposes print media + initial screen rotation as snap config.
 #   snap set ubu4cut print.media=4x6 print.borderless=true
-# Defaults target dye-sub photo printers (4x6 borderless). Values are written to
-# $SNAP_DATA/print-config.env, which run-booth sources for the app.
+#   snap set ubu4cut rotate.turns=2        # 0..3 quarter-turns; 2 = 180° flip
+# Values are written to $SNAP_DATA/print-config.env, which run-booth sources.
 set -e
 
 media="$(snapctl get print.media || true)"
 borderless="$(snapctl get print.borderless || true)"
+turns="$(snapctl get rotate.turns || true)"
 
 if [ -z "$media" ]; then
     media="4x6"
@@ -22,9 +23,17 @@ case "$borderless" in
     *) echo "print.borderless must be true or false" >&2; exit 1 ;;
 esac
 
+if [ -n "$turns" ]; then
+    case "$turns" in
+        0|1|2|3) ;;
+        *) echo "rotate.turns must be 0, 1, 2, or 3 (quarter-turns)" >&2; exit 1 ;;
+    esac
+fi
+
 mkdir -p "$SNAP_DATA"
 umask 022
-cat > "$SNAP_DATA/print-config.env" <<EOF
-BOOTH_PRINT_MEDIA=$media
-BOOTH_PRINT_BORDERLESS=$borderless
-EOF
+{
+    echo "BOOTH_PRINT_MEDIA=$media"
+    echo "BOOTH_PRINT_BORDERLESS=$borderless"
+    [ -n "$turns" ] && echo "BOOTH_ROTATE_TURNS=$turns"
+} > "$SNAP_DATA/print-config.env"

--- a/snap/local/run-booth
+++ b/snap/local/run-booth
@@ -88,11 +88,11 @@ if [ -z "$FLUTTER_BIN" ]; then
     exit 1
 fi
 
-# Print configuration (media/borderless) written by the configure hook.
+# Print + rotation configuration written by the configure hook.
 if [ -f "$SNAP_DATA/print-config.env" ]; then
     # shellcheck disable=SC1091
     . "$SNAP_DATA/print-config.env"
-    export BOOTH_PRINT_MEDIA BOOTH_PRINT_BORDERLESS
+    export BOOTH_PRINT_MEDIA BOOTH_PRINT_BORDERLESS BOOTH_ROTATE_TURNS
 fi
 
 echo "Starting Ubu4Cut ($(date)) — $FLUTTER_BIN"


### PR DESCRIPTION
## Problem
The deployed booth starts **upside down** on a monitor mounted at 180°. The initial-orientation logic only supported 0° / 90° / 270° (`BOOTH_PORTRAIT` + `BOOTH_PORTRAIT_TURNS` = 1|3) — there was **no way to start at 180°**, so a flipped kiosk display couldn't be corrected at boot (only manually via the runtime rotate button, which resets on restart).

## Fix
- `OrientationController._initialTurns` now reads **`BOOTH_ROTATE_TURNS` (0..3)** and uses it directly (`2` = 180°), falling back to the legacy `BOOTH_PORTRAIT` path.
- Exposed as **snap config**: `configure` hook accepts `rotate.turns` (validated 0..3) → `$SNAP_DATA/print-config.env` → `run-booth` exports `BOOTH_ROTATE_TURNS`.
- No more rebuilds to change orientation: `snap set ubu4cut rotate.turns=2 && snap restart ubu4cut.ubu4cut-kiosk`.

Files: `lib/controllers/orientationController.dart`, `snap/hooks/configure`, `snap/local/run-booth`, `README.md`.

## Testing
- `dart format` clean. Building the arm64 snap + deploying to the RPi5 kiosk with `rotate.turns=2` to confirm the flipped display comes up upright.
