### PR TITLE
Camera preview: enlarge, raise, and mirror the live view

### DIFF
--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -326,10 +326,16 @@ class _TakePicturePageState extends State<TakePicturePage>
     
     // 카메라가 초기화되면 실제 GStreamer 위젯 표시
     try {
-      return GstPlayer(
-        pipeline: _getCameraPipeline(),
-        width: kPreviewWidth,
-        height: kPreviewHeight,
+      // Mirror the live view horizontally so posing feels like a mirror. The
+      // capture reads this same flipped render tree via the RepaintBoundary, so
+      // the saved/printed photo matches what the user saw.
+      return Transform.flip(
+        flipX: true,
+        child: GstPlayer(
+          pipeline: _getCameraPipeline(),
+          width: kPreviewWidth,
+          height: kPreviewHeight,
+        ),
       );
     } catch (e) {
       debugPrint('GStreamer initialization error: $e');

--- a/lib/pages/takePicturePage.dart
+++ b/lib/pages/takePicturePage.dart
@@ -20,11 +20,11 @@ class _TakePicturePageState extends State<TakePicturePage>
     with TickerProviderStateMixin {
   // Preview (and captured photo) box. Tunable at runtime via env so the framing
   // can be dialed in without a rebuild — a wider box crops less of the camera's
-  // 4:3 field of view. Defaults keep the original 3:4 portrait.
+  // 4:3 field of view. Large 3:4 portrait default so the live view is prominent.
   static final double kPreviewWidth =
-      double.tryParse(Platform.environment['BOOTH_PREVIEW_WIDTH'] ?? '') ?? 525.0;
+      double.tryParse(Platform.environment['BOOTH_PREVIEW_WIDTH'] ?? '') ?? 660.0;
   static final double kPreviewHeight =
-      double.tryParse(Platform.environment['BOOTH_PREVIEW_HEIGHT'] ?? '') ?? 700.0;
+      double.tryParse(Platform.environment['BOOTH_PREVIEW_HEIGHT'] ?? '') ?? 880.0;
 
   final ImageController imageController = Get.put(ImageController());
   final GlobalKey cameraKey = GlobalKey();
@@ -91,8 +91,12 @@ class _TakePicturePageState extends State<TakePicturePage>
     return BoothScaffold(
       showBack: true,
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
+          // Bias the live view toward the top: the physical camera sits at the
+          // top of the kiosk, so a higher, larger preview keeps eye contact
+          // natural (and the framed portrait dominates the screen).
+          const SizedBox(height: 150),
           // Progress counter
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),


### PR DESCRIPTION
Three capture-screen preview improvements:

- **Enlarge:** default preview box 525x700 → 660x880 (same 3:4 aspect, so the 4-cut print composition is unchanged). Still overridable via `BOOTH_PREVIEW_WIDTH/HEIGHT`.
- **Raise:** top-align the capture column with a 150px offset so the live view sits higher, closer to the physical camera at the top of the kiosk (more natural eye contact).
- **Mirror:** wrap the live `GstPlayer` in `Transform.flip(flipX: true)` so posing feels like a mirror. The capture reads this same flipped render tree via the RepaintBoundary, so the saved/printed photo matches what the user saw. Error/loading states are left un-flipped.

Verified: `flutter test` 3/3, `dart analyze lib` 0 errors/warnings. Built (arm64) and deployed to the RPi5 kiosk — app renders, Frame active, cursor hidden, touch working.