### PR TITLE
Auto-register the dye-sub printer + fix print media (SELPHY)

### DIFF
--- a/ubuntu-core/install-ubuntu-core.md
+++ b/ubuntu-core/install-ubuntu-core.md
@@ -192,21 +192,43 @@ full KMS — go back to [`gadget-camera-kms.md`](gadget-camera-kms.md).
 ## 7. Printing (CUPS + `lp`)
 
 The app composites the four-cut PNG in memory and prints it with the CUPS `lp` client — there
-is no bundled print server. A **Printer Application** (driverless IPP) provides the PNG→raster
-driver for the dye-sub.
+is no bundled print server. Two snaps make up the stack (both installed + wired by
+`setup-ubuntu-core.sh`, which also auto-registers the printer):
+
+- **`cups`** — the CUPS server the booth's `lp` reaches through the `cups` interface.
+- **`gutenprint-printer-app`** — a Printer Application (pappl, listens on `:8000`) that drives
+  the USB dye-sub with a Gutenprint driver and re-exports it as driverless IPP.
+
+`cups` does not auto-discover the Printer Application, so its printer is bridged into `cups`
+as an IPP-Everywhere queue and made the default. The host has no bare `lp*`/`lpadmin` — use
+the cups snap's (`cups.lpstat`, `cups.lpadmin`).
 
 ```bash
-lpstat -p                                    # is the printer discovered?
-sudo lpadmin -d <printer>                    # set the default (or use http://localhost:631)
-snap set ubu4cut print.media=4x6 print.borderless=true
+gutenprint-printer-app devices               # USB printers seen (usb://…)
+sudo cups.lpstat -p -d                       # cups queue + default
+sudo cups.lpstat -W all -o                   # jobs (completed/aborted)
 
-# Diagnose a failed job:
-snap logs ubu4cut
-lpstat -W all
+# Register manually (Canon SELPHY CP1500 uses the protocol-compatible CP1300 driver):
+sudo gutenprint-printer-app add -d SELPHY -v '<usb-uri>' -m canon--selphy-cp-1300--en
+sudo cups.lpadmin -p SELPHY -E -v ipp://localhost:8000/ipp/print/SELPHY -m everywhere
+sudo cups.lpadmin -d SELPHY
+```
+
+**Media must match the printer**, or the job is accepted (`lp` returns 0, the app shows
+"sent") but fails at print time with *"cannot print with supplied options"* and nothing comes
+out. The generic `4x6` (101.6×152.4 mm) is **not** a SELPHY size — it loads
+`om_postcard_105.66x158.5mm`. Set `print.media` to the printer's own `media-default`:
+
+```bash
+sudo cups.ipptool -tv ipp://localhost:8000/ipp/print/SELPHY get-printer-attributes.test \
+  | awk '/media-default \(keyword\)/{print $NF}'      # → om_postcard_105.66x158.5mm
+sudo snap set ubu4cut print.media=om_postcard_105.66x158.5mm print.borderless=true
+sudo snap restart ubu4cut.ubu4cut-kiosk               # media is read at app launch
 ```
 
 `print.media` / `print.borderless` are read by the `configure` hook into
 `$SNAP_DATA/print-config.env`, exported by `run-booth`, and passed to `lp` by the print page.
+
 
 ## 8. Interfaces & confinement
 
@@ -252,7 +274,7 @@ revisions so a bad refresh can be reverted.
 | Nothing on screen under Frame | `ls /dev/dri/card0` (full KMS), `snap services ubuntu-frame`, `snap logs ubu4cut.ubu4cut-kiosk` |
 | Preview shows test pattern / black | `snap logs ubu4cut \| grep Camera:`, `ls /dev/media*`, reconnect `ubu4cut:camera` |
 | Kiosk not autostarting | `snap services ubu4cut` (is `ubu4cut-kiosk` enabled/active?), re-run `snap start --enable ubu4cut.ubu4cut-kiosk` |
-| Print does nothing | `lpstat -p`, default set via `lpadmin -d`, Printer Application installed |
+| Print "sent" but nothing prints | `sudo cups.lpstat -W all -o` + cupsd `error_log` → usually a media mismatch (*"cannot print with supplied options"*); set `print.media` to the printer's `media-default` (§7) |
 | Interface missing | `snap connections ubu4cut` → connect `camera` / `cups` / `wayland` |
 | Touch intermittent / dead after a while | `sudo dmesg \| grep -E 'usb.*(disconnect\|new .*-speed)'` (re-enumerating?), `snap logs ubuntu-frame \| grep -a G2Touch` (touchscreen configured?); install the touch watchdog (§5), stabilise the USB link with a powered USB 2.0 hub |
 

--- a/ubuntu-core/setup-ubuntu-core.sh
+++ b/ubuntu-core/setup-ubuntu-core.sh
@@ -50,6 +50,43 @@ for slotpair in \
     snap connect $slotpair 2>/dev/null || echo "  (skip/verify: snap connect $slotpair)"
 done
 
+echo "-- Registering the connected printer (best-effort) --"
+# The dye-sub is driven by the Gutenprint Printer Application; we then bridge it
+# into the cups snap (the booth's `lp` reaches cups via the `cups` interface) and
+# align the booth's media with the printer so jobs aren't rejected. Device bits
+# are discovered at runtime; override PRINTER_* via env for other hardware.
+PRINTER_NAME="${PRINTER_NAME:-SELPHY}"
+# Canon SELPHY CP1500 has no dedicated model yet but shares the CP1300's
+# Raster3/CA_YCC_ICP protocol, so the CP1300 Gutenprint driver drives it.
+PRINTER_DRIVER="${PRINTER_DRIVER:-canon--selphy-cp-1300--en}"
+PRINTER_APP_PORT="${PRINTER_APP_PORT:-8000}"
+DEV_URI=""
+for _ in $(seq 1 10); do
+    DEV_URI="$("$PRINTER_APP_SNAP" devices 2>/dev/null | grep -m1 '^usb://' || true)"
+    [ -n "$DEV_URI" ] && break
+    sleep 2
+done
+if [ -z "$DEV_URI" ]; then
+    echo "  (no USB printer detected; connect + power it and re-run, or register manually)"
+else
+    echo "  device: $DEV_URI"
+    "$PRINTER_APP_SNAP" add -d "$PRINTER_NAME" -v "$DEV_URI" -m "$PRINTER_DRIVER" \
+        || echo "  (printer-app add failed; check PRINTER_DRIVER=$PRINTER_DRIVER)"
+    "$PRINTER_APP_SNAP" default -d "$PRINTER_NAME" 2>/dev/null || true
+    PAPP_URI="ipp://localhost:${PRINTER_APP_PORT}/ipp/print/${PRINTER_NAME}"
+    cups.lpadmin -p "$PRINTER_NAME" -E -v "$PAPP_URI" -m everywhere \
+        || echo "  (cups bridge failed; is the Printer Application on :$PRINTER_APP_PORT ?)"
+    cups.lpadmin -d "$PRINTER_NAME" 2>/dev/null || true
+    # The app forces `-o media=<print.media>`; a size the printer doesn't list
+    # (generic 4x6 = 101.6x152.4mm vs a SELPHY's 105.66x158.5mm postcard) is
+    # rejected "cannot print with supplied options". Use the printer's default.
+    MEDIA="$(cups.ipptool -tv "$PAPP_URI" get-printer-attributes.test 2>/dev/null \
+        | awk -F'= ' '/media-default \(keyword\)/{gsub(/[[:space:]]/,"",$2); print $2; exit}')"
+    [ -n "$MEDIA" ] && { snap set "$BOOTH_SNAP" print.media="$MEDIA" || true; \
+        echo "  print media set to printer default: $MEDIA"; }
+    echo "  cups default: $(cups.lpstat -d 2>/dev/null || echo '?')"
+fi
+
 echo "-- Enabling the kiosk daemon (install-mode:disable requires explicit enable) --"
 snap start --enable "$KIOSK_APP" || echo "  (verify kiosk app name: $KIOSK_APP)"
 
@@ -60,11 +97,10 @@ Next / verify:
   snap connections ${BOOTH_SNAP}          # confirm camera/cups/wayland are connected
   snap services ${BOOTH_SNAP}             # kiosk daemon should be enabled/active
   snap logs ${KIOSK_APP} -n 50            # boot/render logs
-  # Set the default printer once the dye-sub is detected by the Printer Application:
-  #   lpstat -p            (via the cups snap)
-  #   lpadmin -d <printer> # or the cups web UI at http://localhost:631
-  # Configure photo media (defaults 4x6 / borderless):
-  #   snap set ${BOOTH_SNAP} print.media=4x6 print.borderless=true
+  # Printer auto-registered above (if connected). Verify / adjust:
+  #   cups.lpstat -p -d                      # printer + default (via the cups snap)
+  #   snap get ${BOOTH_SNAP} print.media     # media (auto-set to the printer default)
+  #   snap set ${BOOTH_SNAP} print.media=<keyword> print.borderless=true
 
 CSI camera + full KMS are NOT enabled by this script (gadget-owned config.txt).
 See ubuntu-core/gadget-camera-kms.md.


### PR DESCRIPTION
Fixes 'job sent but nothing prints' on the RPi5 booth. The CUPS stack was installed but the **Canon SELPHY CP1500 was never registered**, and the app forces `-o media=4x6` (101.6×152.4mm) which the SELPHY rejects — it loads postcard **105.66×158.5mm** (`om_postcard_105.66x158.5mm`). `lp` returns 0 so the app shows 'sent', but cupsd aborts with *cannot print with supplied options*.

`setup-ubuntu-core.sh` now auto-discovers the USB printer, registers it (CP1500 via the protocol-compatible **CP1300** Gutenprint driver), bridges it into the cups snap (driverless IPP) as the default, and sets `print.media` to the printer's own `media-default`. install-ubuntu-core.md §7 rewritten for the real two-snap stack + the media-mismatch failure mode. Device already fixed live; this makes it reproducible on re-image. `bash -n` clean.