### PR TITLE
CI, contributor guide, tests, and README refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  analyze-and-test:
+    name: Format · Analyze · Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - run: flutter --version
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed lib test
+
+      - name: Analyze
+        run: dart analyze lib test
+
+      - name: Test
+        run: flutter test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Ubu4Cut
+
+Thanks for your interest in improving Ubu4Cut. This guide covers the local
+workflow and the conventions CI enforces.
+
+## Development setup
+
+Prerequisites: Flutter (Dart SDK ≥ 3.3). Snap builds additionally need a Linux
+host with `snapcraft` (see [`ubuntu-core/build-and-verify.md`](ubuntu-core/build-and-verify.md)).
+
+```bash
+flutter pub get
+flutter run -d linux        # or -d macos for UI-only work
+```
+
+## Before opening a PR
+
+CI runs these on every push and pull request — please run them locally first:
+
+```bash
+dart format lib test                       # formatting (CI fails on diffs)
+dart analyze lib test                      # must report "No issues found!"
+flutter test                               # unit + widget tests
+```
+
+## Conventions
+
+- **Style:** follow `package:flutter_lints`; keep `dart analyze lib test` clean.
+- **File names:** `lower_case_with_underscores.dart`.
+- **Comments:** English, and only where they add non-obvious context.
+- **Device independence:** the app adapts to hardware through environment
+  variables (camera source, print media, preview size). Keep device-specific
+  wiring in [`ubuntu-core/`](ubuntu-core/), not in `lib/`.
+- **Confinement:** the snap runs under strict-ish confinement (currently
+  `devmode` for the Pi CSI camera); avoid adding interfaces or host paths
+  without a matching plug.
+- **Tests & docs:** add tests for new behaviour and update the relevant docs
+  (including `ubuntu-core/` when you touch deployment).
+
+## Commits & PRs
+
+- One logical change per PR; write an imperative subject line
+  (e.g. `Fix greyscale prints on the SELPHY queue`).
+- Describe the problem, the fix, and how you verified it.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ubu4Cut
 
+[![CI](https://github.com/choo121600/flutter-linux-photo-booth/actions/workflows/ci.yml/badge.svg)](https://github.com/choo121600/flutter-linux-photo-booth/actions/workflows/ci.yml)
+
 **Ubu4Cut** is an Ubuntu-based four-cut (네컷) photo booth for touch kiosks. It ships as a
 single Flutter/GTK **snap** that autostarts under **Ubuntu Frame** on **Ubuntu Core**
 (Raspberry Pi 5) and also launches manually on **Ubuntu Desktop**. Point-and-shoot capture,
@@ -14,7 +16,7 @@ installations.
 
 ## Features
 
-- **Two capture layouts** — 1-cut (`1장`) and 4-cut (`4장`), each with a live countdown.
+- **Two capture layouts** — 1-cut and 4-cut, each with a live countdown.
 - **Real-time preview** via GStreamer — USB UVC (`v4l2src`) and Raspberry Pi CSI
   (`libcamerasrc`, PiSP) are auto-detected at launch.
 - **Frame overlays** composited onto the captured shots before printing.
@@ -117,10 +119,10 @@ server.
 
 - Install CUPS and a **driverless-IPP Printer Application** for the dye-sub, e.g.
   `gutenprint-printer-app` (`setup-ubuntu-core.sh` installs both).
-- Set the default printer once it is detected:
+- `setup-ubuntu-core.sh` auto-registers a connected USB printer; verify or adjust:
   ```bash
-  lpstat -p                  # via the cups snap
-  sudo lpadmin -d <printer>  # or the CUPS web UI at http://localhost:631
+  cups.lpstat -p -d              # printer + default (via the cups snap)
+  sudo cups.lpadmin -d <printer> # or the CUPS web UI at http://localhost:631
   ```
 - Configure photo media (defaults: **4×6 borderless**):
   ```bash
@@ -151,9 +153,10 @@ Runtime-tunable at startup, no rebuild required:
 | Variable | Default | Effect |
 |---|---|---|
 | `BOOTH_TAP_GUARD_MS` | `300` | Post-transition input guard; `0` disables it. |
-| `BOOTH_PREVIEW_WIDTH` / `BOOTH_PREVIEW_HEIGHT` | `525` / `700` | Preview & capture box size. |
+| `BOOTH_PREVIEW_WIDTH` / `BOOTH_PREVIEW_HEIGHT` | `660` / `880` | Preview & capture box size. |
 | `BOOTH_CAMERA_KIND` / `DEFAULT_CAMERA_DEVICE` | auto | Override camera detection. |
 | `BOOTH_PRINT_MEDIA` / `BOOTH_PRINT_BORDERLESS` | `4x6` / `true` | Set via `snap set … print.*`. |
+| `BOOTH_PRINT_WAIT_SEC` | `45` | Seconds the "Printing…" overlay blocks input (covers the print). |
 | `BOOTH_AUTOSTART_CAMERA` | unset | Test hook: auto-open the camera page. Off in production. |
 
 `print.media` / `print.borderless` are exposed as snap config (`snap set ubu4cut …`); the
@@ -206,14 +209,14 @@ Notes:
 ```
 ubu4cut/
 ├── lib/
-│   ├── main.dart                 # App entry: routes, theme, whole-UI rotation
-│   ├── controllers/              # GetX controllers (image buffer, orientation)
+│   ├── main.dart                 # App entry: routes + theme
+│   ├── controllers/              # GetX controller (captured-image buffer)
 │   ├── pages/                    # home / take-picture / print
-│   ├── widgets/                  # tapGuard (post-transition input guard)
+│   ├── widgets/                  # booth_scaffold, tap_guard (input guard)
 │   └── helpers/                  # frame-overlay compositing
 ├── assets/
-│   ├── images/                   # frame templates + test images
-│   └── backgrounds/              # UI backgrounds
+│   ├── images/                   # four-cut frame template
+│   └── fonts/                    # Ubuntu (+ Noto Sans KR fallback)
 ├── snap/
 │   ├── snapcraft.yaml            # snap (gnome ext, libcamera-from-source, dual apps)
 │   ├── hooks/configure           # print.media / print.borderless -> env

--- a/test/image_controller_test.dart
+++ b/test/image_controller_test.dart
@@ -10,14 +10,28 @@ void main() {
       controller = ImageController();
     });
 
-    test('starts with empty capturedImages list', () {
+    test('starts with an empty capturedImages list', () {
       expect(controller.capturedImages, isEmpty);
     });
 
     test('can add captured images', () {
-      final testData = ByteData(10);
-      controller.capturedImages.add(testData);
+      controller.capturedImages.add(ByteData(10));
       expect(controller.capturedImages.length, 1);
+    });
+
+    test('preserves insertion order', () {
+      final first = ByteData(1);
+      final second = ByteData(2);
+      controller.capturedImages.addAll([first, second]);
+      expect(controller.capturedImages, [first, second]);
+    });
+
+    test('reset() clears a full four-cut buffer', () {
+      controller.capturedImages.addAll(List.generate(4, (_) => ByteData(10)));
+      expect(controller.capturedImages.length, 4);
+
+      controller.reset();
+      expect(controller.capturedImages, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Project-hygiene pass toward global standards (follow-up to the #25 refactor).

- **CI** — `.github/workflows/ci.yml` runs a format check, `dart analyze lib test` (clean), and `flutter test` on every push/PR.
- **CONTRIBUTING.md** — local workflow + the conventions CI enforces.
- **Tests** — expand `ImageController` coverage (insertion order, reset of a full four-cut buffer); `flutter test` now 5/5.
- **README** — fix stale bits (Korean cut labels → English, preview default 660/880, `cups.lpstat`/`cups.lpadmin`, new `BOOTH_PRINT_WAIT_SEC`, project structure) and add a CI badge.

Verified locally: format clean, `dart analyze lib test` = No issues, `flutter test` 5/5.