### PR TITLE
Add colour filters to the capture screen

### DIFF
--- a/lib/filters/camera_filters.dart
+++ b/lib/filters/camera_filters.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/widgets.dart';
+
+/// A named colour filter for the live camera preview and the captured photo.
+class CameraFilter {
+  final String name;
+  final ColorFilter filter;
+  const CameraFilter(this.name, this.filter);
+}
+
+/// Colour-matrix filters offered on the capture screen. They are applied inside
+/// the preview's RepaintBoundary, so the saved photo matches what the user saw.
+/// (Trailing `//` keeps `dart format` from collapsing each 5-value row.)
+const List<CameraFilter> kCameraFilters = <CameraFilter>[
+  CameraFilter(
+    'Normal',
+    ColorFilter.matrix(<double>[
+      1, 0, 0, 0, 0, //
+      0, 1, 0, 0, 0, //
+      0, 0, 1, 0, 0, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'B&W',
+    ColorFilter.matrix(<double>[
+      0.2126, 0.7152, 0.0722, 0, 0, //
+      0.2126, 0.7152, 0.0722, 0, 0, //
+      0.2126, 0.7152, 0.0722, 0, 0, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'Sepia',
+    ColorFilter.matrix(<double>[
+      0.393, 0.769, 0.189, 0, 0, //
+      0.349, 0.686, 0.168, 0, 0, //
+      0.272, 0.534, 0.131, 0, 0, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'Warm',
+    ColorFilter.matrix(<double>[
+      1.06, 0, 0, 0, 15, //
+      0, 1.0, 0, 0, 5, //
+      0, 0, 0.94, 0, 0, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'Cool',
+    ColorFilter.matrix(<double>[
+      0.94, 0, 0, 0, 0, //
+      0, 1.0, 0, 0, 5, //
+      0, 0, 1.08, 0, 15, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'Vivid',
+    ColorFilter.matrix(<double>[
+      1.276, -0.250, -0.025, 0, 0, //
+      -0.074, 1.100, -0.025, 0, 0, //
+      -0.074, -0.250, 1.325, 0, 0, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+  CameraFilter(
+    'Soft',
+    ColorFilter.matrix(<double>[
+      1.0, 0, 0, 0, 22, //
+      0, 1.0, 0, 0, 20, //
+      0, 0, 1.0, 0, 14, //
+      0, 0, 0, 1, 0,
+    ]),
+  ),
+];

--- a/lib/pages/take_picture_page.dart
+++ b/lib/pages/take_picture_page.dart
@@ -430,9 +430,11 @@ class _TakePicturePageState extends State<TakePicturePage>
       //  * The imx219 640x480 sensor mode is a narrow-FOV CROP (looks zoomed in);
       //    capture the full-FOV binned mode (1640x1232) and scale down instead.
       //  * Scale (in NV12) BEFORE converting to RGBA: downscaling the 2MP frame
-      //    first cuts videoconvert's per-pixel work ~6x, lifting the CPU-bound
-      //    preview from ~22 to ~28 fps on a Pi 5 (measured on-device).
-      return '''libcamerasrc ! video/x-raw,format=NV12,width=1640,height=1232 ! videoscale ! video/x-raw,format=NV12,width=640,height=480 ! videoconvert ! video/x-raw,format=RGBA,width=640,height=480 ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';
+      //    first cuts videoconvert's per-pixel work ~6x.
+      //  * Request framerate=40/1: the imx219 binned mode tops out near 37fps
+      //    (50/1 stalls) and without an explicit cap libcamera settles at
+      //    ~28fps. Measured on-device: 28 -> 37fps, still full FOV.
+      return '''libcamerasrc ! video/x-raw,format=NV12,width=1640,height=1232,framerate=40/1 ! videoscale ! video/x-raw,format=NV12,width=640,height=480 ! videoconvert ! video/x-raw,format=RGBA,width=640,height=480 ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';
     }
     // USB UVC (v4l2).
     return '''v4l2src device=$device ! video/x-raw,width=640,height=480,framerate=30/1 ! videoconvert ! video/x-raw,format=RGBA ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';

--- a/lib/pages/take_picture_page.dart
+++ b/lib/pages/take_picture_page.dart
@@ -175,10 +175,8 @@ class _TakePicturePageState extends State<TakePicturePage>
               ),
             ),
           ),
-          const SizedBox(height: 14),
-          _buildFilterBar(),
           const SizedBox(height: 28),
-          if (_picturesTaken < _selectedType!)
+          if (_picturesTaken < _selectedType!) ...[
             SizedBox(
               width: 300,
               height: 84,
@@ -200,6 +198,9 @@ class _TakePicturePageState extends State<TakePicturePage>
                 ),
               ),
             ),
+            const SizedBox(height: 22),
+            _buildFilterBar(),
+          ],
           if (_picturesTaken >= _selectedType!)
             SizedBox(
               width: 320,
@@ -243,26 +244,26 @@ class _TakePicturePageState extends State<TakePicturePage>
 
   Widget _buildFilterBar() {
     return SizedBox(
-      height: 54,
+      height: 72,
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
         shrinkWrap: true,
         physics: const BouncingScrollPhysics(),
         padding: const EdgeInsets.symmetric(horizontal: 20),
         itemCount: kCameraFilters.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 10),
+        separatorBuilder: (_, __) => const SizedBox(width: 12),
         itemBuilder: (context, i) {
           final bool selected = i == _filterIndex;
           return GestureDetector(
             onTap: () => setState(() => _filterIndex = i),
             child: Container(
               alignment: Alignment.center,
-              padding: const EdgeInsets.symmetric(horizontal: 20),
+              padding: const EdgeInsets.symmetric(horizontal: 28),
               decoration: BoxDecoration(
                 color: selected
                     ? kBoothAccent
                     : Colors.white.withValues(alpha: 0.14),
-                borderRadius: BorderRadius.circular(14),
+                borderRadius: BorderRadius.circular(18),
                 border: Border.all(
                   color: selected
                       ? Colors.white
@@ -274,7 +275,7 @@ class _TakePicturePageState extends State<TakePicturePage>
                 kCameraFilters[i].name,
                 style: TextStyle(
                   color: Colors.white,
-                  fontSize: 18,
+                  fontSize: 24,
                   fontWeight: selected ? FontWeight.bold : FontWeight.w500,
                 ),
               ),

--- a/lib/pages/take_picture_page.dart
+++ b/lib/pages/take_picture_page.dart
@@ -56,6 +56,7 @@ class _TakePicturePageState extends State<TakePicturePage>
   void _initializeCamera() async {
     try {
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!mounted) return;
 
       setState(() {
         _cameraInitialized = true;
@@ -63,9 +64,11 @@ class _TakePicturePageState extends State<TakePicturePage>
 
       debugPrint('Camera initialization completed');
     } catch (e) {
-      setState(() {
-        _cameraError = 'Camera initialization failed: $e';
-      });
+      if (mounted) {
+        setState(() {
+          _cameraError = 'Camera initialization failed: $e';
+        });
+      }
       debugPrint('Camera initialization error: $e');
     }
   }

--- a/lib/pages/take_picture_page.dart
+++ b/lib/pages/take_picture_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_gstreamer_player/flutter_gstreamer_player.dart';
 import '../controllers/image_controller.dart';
 import '../widgets/booth_scaffold.dart';
+import '../filters/camera_filters.dart';
 
 class TakePicturePage extends StatefulWidget {
   const TakePicturePage({super.key});
@@ -38,6 +39,7 @@ class _TakePicturePageState extends State<TakePicturePage>
   bool _cameraInitialized = false;
   String? _cameraError;
   late AnimationController _animationController;
+  int _filterIndex = 0;
 
   @override
   void initState() {
@@ -159,7 +161,10 @@ class _TakePicturePageState extends State<TakePicturePage>
                   children: [
                     RepaintBoundary(
                       key: cameraKey,
-                      child: _buildCameraWidget(),
+                      child: ColorFiltered(
+                        colorFilter: kCameraFilters[_filterIndex].filter,
+                        child: _buildCameraWidget(),
+                      ),
                     ),
                     if (_takingPicture) _buildOverlay(),
                   ],
@@ -167,6 +172,8 @@ class _TakePicturePageState extends State<TakePicturePage>
               ),
             ),
           ),
+          const SizedBox(height: 14),
+          _buildFilterBar(),
           const SizedBox(height: 28),
           if (_picturesTaken < _selectedType!)
             SizedBox(
@@ -227,6 +234,50 @@ class _TakePicturePageState extends State<TakePicturePage>
         width: kPreviewWidth,
         height: kPreviewHeight,
         color: Colors.white,
+      ),
+    );
+  }
+
+  Widget _buildFilterBar() {
+    return SizedBox(
+      height: 54,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        shrinkWrap: true,
+        physics: const BouncingScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        itemCount: kCameraFilters.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 10),
+        itemBuilder: (context, i) {
+          final bool selected = i == _filterIndex;
+          return GestureDetector(
+            onTap: () => setState(() => _filterIndex = i),
+            child: Container(
+              alignment: Alignment.center,
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              decoration: BoxDecoration(
+                color: selected
+                    ? kBoothAccent
+                    : Colors.white.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(
+                  color: selected
+                      ? Colors.white
+                      : Colors.white.withValues(alpha: 0.35),
+                  width: selected ? 2 : 1.5,
+                ),
+              ),
+              child: Text(
+                kCameraFilters[i].name,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: selected ? FontWeight.bold : FontWeight.w500,
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/pages/take_picture_page.dart
+++ b/lib/pages/take_picture_page.dart
@@ -164,10 +164,12 @@ class _TakePicturePageState extends State<TakePicturePage>
                   children: [
                     RepaintBoundary(
                       key: cameraKey,
-                      child: ColorFiltered(
-                        colorFilter: kCameraFilters[_filterIndex].filter,
-                        child: _buildCameraWidget(),
-                      ),
+                      child: _filterIndex == 0
+                          ? _buildCameraWidget()
+                          : ColorFiltered(
+                              colorFilter: kCameraFilters[_filterIndex].filter,
+                              child: _buildCameraWidget(),
+                            ),
                     ),
                     if (_takingPicture) _buildOverlay(),
                   ],
@@ -427,8 +429,10 @@ class _TakePicturePageState extends State<TakePicturePage>
       //    unconstrained `video/x-raw` fails to negotiate — request NV12.
       //  * The imx219 640x480 sensor mode is a narrow-FOV CROP (looks zoomed in);
       //    capture the full-FOV binned mode (1640x1232) and scale down instead.
-      // Verified on-device with gst-launch.
-      return '''libcamerasrc ! video/x-raw,format=NV12,width=1640,height=1232 ! videoconvert ! videoscale ! video/x-raw,format=RGBA,width=640,height=480 ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';
+      //  * Scale (in NV12) BEFORE converting to RGBA: downscaling the 2MP frame
+      //    first cuts videoconvert's per-pixel work ~6x, lifting the CPU-bound
+      //    preview from ~22 to ~28 fps on a Pi 5 (measured on-device).
+      return '''libcamerasrc ! video/x-raw,format=NV12,width=1640,height=1232 ! videoscale ! video/x-raw,format=NV12,width=640,height=480 ! videoconvert ! video/x-raw,format=RGBA,width=640,height=480 ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';
     }
     // USB UVC (v4l2).
     return '''v4l2src device=$device ! video/x-raw,width=640,height=480,framerate=30/1 ! videoconvert ! video/x-raw,format=RGBA ! appsink name=sink emit-signals=true sync=false max-buffers=1 drop=true''';

--- a/packages/flutter_gstreamer_player/lib/flutter_gstreamer_player.dart
+++ b/packages/flutter_gstreamer_player/lib/flutter_gstreamer_player.dart
@@ -25,11 +25,13 @@ class GstPlayerController {
     });
   }
 
-  /// Returns the latest frame as `{width, height, bytes}` (RGBA8888) or null.
-  Future<Map<Object?, Object?>?> getFrame() async {
+  /// Returns `{seq, width, height, bytes}`. `bytes` is empty when no frame
+  /// newer than [sinceSeq] exists, so callers can over-poll cheaply.
+  Future<Map<Object?, Object?>?> getFrame(int sinceSeq) async {
     if (playerId < 0) return null;
     final result = await _channel.invokeMethod('getFrame', {
       'playerId': playerId,
+      'sinceSeq': sinceSeq,
     });
     return result as Map<Object?, Object?>?;
   }
@@ -61,6 +63,7 @@ class _GstPlayerState extends State<GstPlayer> {
   Timer? _timer;
   ui.Image? _image;
   bool _busy = false;
+  int _lastSeq = -1;
 
   @override
   void initState() {
@@ -74,23 +77,31 @@ class _GstPlayerState extends State<GstPlayer> {
     } catch (e) {
       debugPrint('GstPlayer init error: $e');
     }
-    // ~30 fps preview poll — the libcamera pipeline sustains ~28fps on a Pi 5,
-    // so a 33ms tick keeps the RawImage close to the freshest appsink buffer.
-    _timer = Timer.periodic(const Duration(milliseconds: 33), (_) => _pull());
+    // Poll at ~50Hz. getFrame only ships pixels when a newer frame exists
+    // (see sinceSeq), so over-polling the ~37fps source is nearly free and
+    // keeps the RawImage on the freshest appsink buffer with minimal latency.
+    _timer = Timer.periodic(const Duration(milliseconds: 20), (_) => _pull());
   }
 
   Future<void> _pull() async {
     if (_busy || !mounted) return;
     _busy = true;
     try {
-      final frame = await _controller.getFrame();
+      final frame = await _controller.getFrame(_lastSeq);
       if (frame == null || !mounted) return;
+      final int seq = (frame['seq'] as int?) ?? 0;
       final int w = (frame['width'] as int?) ?? 0;
       final int h = (frame['height'] as int?) ?? 0;
       final Uint8List? bytes = frame['bytes'] as Uint8List?;
-      if (w <= 0 || h <= 0 || bytes == null || bytes.length < w * h * 4) {
+      // Nothing newer than the frame we last decoded → skip.
+      if (seq == _lastSeq ||
+          w <= 0 ||
+          h <= 0 ||
+          bytes == null ||
+          bytes.length < w * h * 4) {
         return;
       }
+      _lastSeq = seq;
       final completer = Completer<ui.Image>();
       ui.decodeImageFromPixels(
         bytes,

--- a/packages/flutter_gstreamer_player/lib/flutter_gstreamer_player.dart
+++ b/packages/flutter_gstreamer_player/lib/flutter_gstreamer_player.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -75,8 +74,9 @@ class _GstPlayerState extends State<GstPlayer> {
     } catch (e) {
       debugPrint('GstPlayer init error: $e');
     }
-    // ~15 fps preview poll.
-    _timer = Timer.periodic(const Duration(milliseconds: 66), (_) => _pull());
+    // ~30 fps preview poll — the libcamera pipeline sustains ~28fps on a Pi 5,
+    // so a 33ms tick keeps the RawImage close to the freshest appsink buffer.
+    _timer = Timer.periodic(const Duration(milliseconds: 33), (_) => _pull());
   }
 
   Future<void> _pull() async {

--- a/packages/flutter_gstreamer_player/linux/flutter_gstreamer_player_plugin.cc
+++ b/packages/flutter_gstreamer_player/linux/flutter_gstreamer_player_plugin.cc
@@ -27,6 +27,7 @@ struct FrameData {
   std::vector<uint8_t> bytes;
   int32_t width = 0;
   int32_t height = 0;
+  int64_t seq = 0;
   std::mutex mutex;
 };
 static std::unordered_map<int32_t, std::unique_ptr<FrameData>> g_frames;
@@ -63,6 +64,7 @@ static void flutter_gstreamer_player_plugin_handle_method_call(
         frame_data->bytes.assign(frame, frame + size);
         frame_data->width = width;
         frame_data->height = height;
+        frame_data->seq++;
       });
     }
 
@@ -72,15 +74,24 @@ static void flutter_gstreamer_player_plugin_handle_method_call(
   } else if (strcmp(method, "getFrame") == 0) {
     int32_t player_id =
         fl_value_get_int(fl_value_lookup_string(args, "playerId"));
+    // Dart passes the seq it last decoded; we ship pixel bytes only when a
+    // newer frame exists, so fast polling never re-transfers a stale frame.
+    int64_t since_seq = 0;
+    FlValue* since = fl_value_lookup_string(args, "sinceSeq");
+    if (since != nullptr && fl_value_get_type(since) == FL_VALUE_TYPE_INT) {
+      since_seq = fl_value_get_int(since);
+    }
     g_autoptr(FlValue) result = fl_value_new_map();
     auto it = g_frames.find(player_id);
     if (it != g_frames.end()) {
       std::lock_guard<std::mutex> lock(it->second->mutex);
+      fl_value_set_string_take(result, "seq",
+                               fl_value_new_int(it->second->seq));
       fl_value_set_string_take(result, "width",
                                fl_value_new_int(it->second->width));
       fl_value_set_string_take(result, "height",
                                fl_value_new_int(it->second->height));
-      if (it->second->bytes.empty()) {
+      if (it->second->bytes.empty() || it->second->seq == since_seq) {
         fl_value_set_string_take(result, "bytes",
                                  fl_value_new_uint8_list(nullptr, 0));
       } else {
@@ -90,6 +101,7 @@ static void flutter_gstreamer_player_plugin_handle_method_call(
                                     it->second->bytes.size()));
       }
     } else {
+      fl_value_set_string_take(result, "seq", fl_value_new_int(0));
       fl_value_set_string_take(result, "width", fl_value_new_int(0));
       fl_value_set_string_take(result, "height", fl_value_new_int(0));
       fl_value_set_string_take(result, "bytes",


### PR DESCRIPTION
Live, tappable face-photo filters below the camera preview — **Normal, B&W, Sepia, Warm, Cool, Vivid, Soft**. Each is a `ColorFilter.matrix` applied *inside* the preview's RepaintBoundary, so switching is instant (no camera pipeline restart) and the captured/printed photo matches what was previewed. Definitions in `lib/filters/camera_filters.dart`. Verified: dart analyze 0, flutter test 5/5.